### PR TITLE
Qualify Visitable protocol member names with "visitable"

### DIFF
--- a/Turbolinks/Session.swift
+++ b/Turbolinks/Session.swift
@@ -41,7 +41,7 @@ public class Session: NSObject, WebViewDelegate, VisitDelegate, VisitableDelegat
     }
     
     func visitVisitable(visitable: Visitable, action: Action) {
-        if visitable.URL != nil {
+        if visitable.visitableURL != nil {
             let visit: Visit
 
             if initialized {
@@ -77,7 +77,7 @@ public class Session: NSObject, WebViewDelegate, VisitDelegate, VisitableDelegat
                 deactivateVisitable(activatedVisitable, showScreenshot: true)
             }
 
-            visitable.activateWebView(webView)
+            visitable.activateVisitableWebView(webView)
             activatedVisitable = visitable
         }
     }
@@ -85,11 +85,11 @@ public class Session: NSObject, WebViewDelegate, VisitDelegate, VisitableDelegat
     func deactivateVisitable(visitable: Visitable, showScreenshot: Bool = false) {
         if visitable === activatedVisitable {
             if showScreenshot {
-                visitable.updateScreenshot()
-                visitable.showScreenshot()
+                visitable.updateVisitableScreenshot()
+                visitable.showVisitableScreenshot()
             }
 
-            visitable.deactivateWebView()
+            visitable.deactivateVisitableWebView()
             activatedVisitable = nil
         }
     }
@@ -114,9 +114,9 @@ public class Session: NSObject, WebViewDelegate, VisitDelegate, VisitableDelegat
 
     func webViewDidInvalidatePage(webView: WebView) {
         if let visitable = topmostVisitable {
-            visitable.updateScreenshot()
-            visitable.showScreenshot()
-            visitable.showActivityIndicator()
+            visitable.updateVisitableScreenshot()
+            visitable.showVisitableScreenshot()
+            visitable.showVisitableActivityIndicator()
             reload()
         }
     }
@@ -134,29 +134,29 @@ public class Session: NSObject, WebViewDelegate, VisitDelegate, VisitableDelegat
     func visitDidInitializeWebView(visit: Visit) {
         initialized = true
         delegate?.sessionDidInitializeWebView(self)
-        visit.visitable.didRender?()
+        visit.visitable.visitableDidRender?()
     }
 
     func visitWillStart(visit: Visit) {
-        visit.visitable.showScreenshot()
+        visit.visitable.showVisitableScreenshot()
         activateVisitable(visit.visitable)
     }
    
     func visitDidStart(visit: Visit) {
         if !visit.hasCachedSnapshot {
-            visit.visitable.showActivityIndicator()
+            visit.visitable.showVisitableActivityIndicator()
         }
     }
 
     func visitWillLoadResponse(visit: Visit) {
-        visit.visitable.updateScreenshot()
-        visit.visitable.showScreenshot()
+        visit.visitable.updateVisitableScreenshot()
+        visit.visitable.showVisitableScreenshot()
     }
 
     func visitDidRender(visit: Visit) {
-        visit.visitable.hideScreenshot()
-        visit.visitable.hideActivityIndicator()
-        visit.visitable.didRender?()
+        visit.visitable.hideVisitableScreenshot()
+        visit.visitable.hideVisitableActivityIndicator()
+        visit.visitable.visitableDidRender?()
     }
 
     func visitDidComplete(visit: Visit) {
@@ -166,7 +166,7 @@ public class Session: NSObject, WebViewDelegate, VisitDelegate, VisitableDelegat
 
         if refreshing {
             refreshing = false
-            visit.visitable.didRefresh()
+            visit.visitable.visitableDidRefresh()
         }
     }
 
@@ -192,7 +192,7 @@ public class Session: NSObject, WebViewDelegate, VisitDelegate, VisitableDelegat
 
     public func visitableViewWillAppear(visitable: Visitable) {
         if let topmostVisit = self.topmostVisit, currentVisit = self.currentVisit {
-            if visitable === topmostVisit.visitable && visitable.viewController.isMovingToParentViewController() {
+            if visitable === topmostVisit.visitable && visitable.visitableViewController.isMovingToParentViewController() {
                 // Back swipe gesture canceled
                 if topmostVisit.state == .Completed {
                     currentVisit.cancel()
@@ -218,8 +218,8 @@ public class Session: NSObject, WebViewDelegate, VisitDelegate, VisitableDelegat
             }
         } else if visitable === topmostVisit?.visitable && topmostVisit?.state == .Completed {
             // Reappearing after canceled navigation
-            visitable.hideScreenshot()
-            visitable.hideActivityIndicator()
+            visitable.hideVisitableScreenshot()
+            visitable.hideVisitableActivityIndicator()
             activateVisitable(visitable)
         }
     }
@@ -227,7 +227,7 @@ public class Session: NSObject, WebViewDelegate, VisitDelegate, VisitableDelegat
     public func visitableDidRequestRefresh(visitable: Visitable) {
         if visitable === topmostVisitable {
             refreshing = true
-            visitable.willRefresh()
+            visitable.visitableWillRefresh()
             reload()
         }
     }

--- a/Turbolinks/Visit.swift
+++ b/Turbolinks/Visit.swift
@@ -42,7 +42,7 @@ class Visit: NSObject {
 
     init(visitable: Visitable, action: Action, webView: WebView) {
         self.visitable = visitable
-        self.location = visitable.URL!
+        self.location = visitable.visitableURL!
         self.action = action
         self.webView = webView
         self.state = .Initialized

--- a/Turbolinks/Visitable.swift
+++ b/Turbolinks/Visitable.swift
@@ -10,21 +10,21 @@ import WebKit
 @objc public protocol Visitable: class {
     weak var visitableDelegate: VisitableDelegate? { get set }
 
-    var URL: NSURL? { get set }
-    var viewController: UIViewController { get }
+    var visitableURL: NSURL? { get set }
+    var visitableViewController: UIViewController { get }
 
-    func activateWebView(webView: WKWebView)
-    func deactivateWebView()
+    func activateVisitableWebView(webView: WKWebView)
+    func deactivateVisitableWebView()
 
-    func showActivityIndicator()
-    func hideActivityIndicator()
+    func showVisitableActivityIndicator()
+    func hideVisitableActivityIndicator()
 
-    func updateScreenshot()
-    func showScreenshot()
-    func hideScreenshot()
+    func updateVisitableScreenshot()
+    func showVisitableScreenshot()
+    func hideVisitableScreenshot()
 
-    func willRefresh()
-    func didRefresh()
+    func visitableWillRefresh()
+    func visitableDidRefresh()
 
-    optional func didRender()
+    optional func visitableDidRender()
 }

--- a/TurbolinksDemo/ApplicationController.swift
+++ b/TurbolinksDemo/ApplicationController.swift
@@ -45,7 +45,7 @@ class ApplicationController: UIViewController, WKNavigationDelegate, SessionDele
     private func presentVisitableForSession(session: Session, URL: NSURL, action: Action = .Advance) {
         if let navigationController = mainNavigationController {
             let visitable = visitableForSession(session, URL: URL)
-            let viewController = visitable.viewController
+            let viewController = visitable.visitableViewController
 
             if action == .Advance {
                 navigationController.pushViewController(viewController, animated: true)
@@ -60,7 +60,7 @@ class ApplicationController: UIViewController, WKNavigationDelegate, SessionDele
 
     private func visitableForSession(session: Session, URL: NSURL) -> Visitable {
         let visitable = WebViewController()
-        visitable.URL = URL
+        visitable.visitableURL = URL
         visitable.visitableDelegate = session
         return visitable
     }
@@ -101,7 +101,7 @@ class ApplicationController: UIViewController, WKNavigationDelegate, SessionDele
             self.presentAuthenticationController()
           }
         } else {
-            session.topmostVisitable?.hideActivityIndicator()
+            session.topmostVisitable?.hideVisitableActivityIndicator()
             presentAlertForError(error)
         }
     }

--- a/TurbolinksDemo/WebViewController.swift
+++ b/TurbolinksDemo/WebViewController.swift
@@ -5,8 +5,8 @@ import Turbolinks
 class WebViewController: UIViewController, Visitable {
     weak var visitableDelegate: VisitableDelegate?
 
-    var URL: NSURL?
-    var viewController: UIViewController { return self }
+    var visitableURL: NSURL?
+    var visitableViewController: UIViewController { return self }
 
     // MARK: View Lifecycle
     
@@ -29,11 +29,7 @@ class WebViewController: UIViewController, Visitable {
 
     // MARK: Visitable Lifecycle
 
-    func didRender() {
-        updateTitle()
-    }
-
-    private func updateTitle() {
+    func visitableDidRender() {
         title = webView?.title
     }
 
@@ -41,7 +37,7 @@ class WebViewController: UIViewController, Visitable {
 
     var webView: WKWebView?
 
-    func activateWebView(webView: WKWebView) {
+    func activateVisitableWebView(webView: WKWebView) {
         self.webView = webView
 
         view.addSubview(webView)
@@ -52,7 +48,7 @@ class WebViewController: UIViewController, Visitable {
         installRefreshControl()
     }
 
-    func deactivateWebView() {
+    func deactivateVisitableWebView() {
         removeRefreshControl()
         webView?.removeFromSuperview()
         webView = nil
@@ -88,14 +84,14 @@ class WebViewController: UIViewController, Visitable {
         view.addConstraint(NSLayoutConstraint(item: activityIndicator, attribute: .CenterY, relatedBy: .Equal, toItem: view, attribute: .CenterY, multiplier: 1, constant: 0))
     }
 
-    func showActivityIndicator() {
+    func showVisitableActivityIndicator() {
         if !refreshing {
             activityIndicator.startAnimating()
             view.bringSubviewToFront(activityIndicator)
         }
     }
 
-    func hideActivityIndicator() {
+    func hideVisitableActivityIndicator() {
         activityIndicator.stopAnimating()
     }
 
@@ -108,25 +104,25 @@ class WebViewController: UIViewController, Visitable {
         return screenshotView
     }()
     
-    private var screenshotVisible: Bool {
+    private var showingScreenshot: Bool {
         return screenshotView.superview == view
     }
 
-    func updateScreenshot() {
-        if !screenshotVisible {
+    func updateVisitableScreenshot() {
+        if !showingScreenshot {
             self.screenshotView = view.snapshotViewAfterScreenUpdates(false)
         }
     }
 
-    func showScreenshot() {
-        if !screenshotVisible && !refreshing {
+    func showVisitableScreenshot() {
+        if !showingScreenshot && !refreshing {
             view.addSubview(screenshotView)
             view.addConstraints(NSLayoutConstraint.constraintsWithVisualFormat("H:|[view]|", options: [], metrics: nil, views: [ "view": screenshotView ]))
             view.addConstraints(NSLayoutConstraint.constraintsWithVisualFormat("V:|[view]|", options: [], metrics: nil, views: [ "view": screenshotView ]))
         }
     }
 
-    func hideScreenshot() {
+    func hideVisitableScreenshot() {
         screenshotView.removeFromSuperview()
     }
 
@@ -155,11 +151,11 @@ class WebViewController: UIViewController, Visitable {
         visitableDelegate?.visitableDidRequestRefresh(self)
     }
 
-    func willRefresh() {
+    func visitableWillRefresh() {
         refreshControl.beginRefreshing()
     }
 
-    func didRefresh() {
+    func visitableDidRefresh() {
         after(50) {
             self.refreshControl.endRefreshing()
         }


### PR DESCRIPTION
Include "visitable" in names to make it clear what they pertain to, and for politeness, to avoid imposing on implementors.

``` swift
weak var visitableDelegate: VisitableDelegate? { get set }

var visitableURL: NSURL? { get set }
var visitableViewController: UIViewController { get }

func activateVisitableWebView(webView: WKWebView)
func deactivateVisitableWebView()

func showVisitableActivityIndicator()
func hideVisitableActivityIndicator()

func updateVisitableScreenshot()
func showVisitableScreenshot()
func hideVisitableScreenshot()

func visitableWillRefresh()
func visitableDidRefresh()

optional func visitableDidRender()
```
