### PR TITLE
Make Visitable's UIRefreshControl-related methods optional

### DIFF
--- a/Turbolinks/Session.swift
+++ b/Turbolinks/Session.swift
@@ -166,7 +166,7 @@ extension Session: VisitDelegate {
 
         if refreshing {
             refreshing = false
-            visit.visitable.visitableDidRefresh()
+            visit.visitable.visitableDidRefresh?()
         }
     }
 
@@ -215,7 +215,7 @@ extension Session: VisitableDelegate {
     public func visitableDidRequestRefresh(visitable: Visitable) {
         if visitable === topmostVisitable {
             refreshing = true
-            visitable.visitableWillRefresh()
+            visitable.visitableWillRefresh?()
             reload()
         }
     }

--- a/Turbolinks/Visitable.swift
+++ b/Turbolinks/Visitable.swift
@@ -23,8 +23,8 @@ import WebKit
     func showVisitableScreenshot()
     func hideVisitableScreenshot()
 
-    func visitableWillRefresh()
-    func visitableDidRefresh()
+    optional func visitableWillRefresh()
+    optional func visitableDidRefresh()
 
     optional func visitableDidRender()
 }


### PR DESCRIPTION
Make the Visitable protocol's `visitableWillRefresh` and `visitableDidRefresh` methods optional. Visitable needn't assume you want to use pull-to-refresh.
