### PR TITLE
Add an example of navigating natively

### DIFF
--- a/TurbolinksDemo.xcodeproj/project.pbxproj
+++ b/TurbolinksDemo.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		22CB5D901C62981700F24EA7 /* Turbolinks.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 22CB5D8D1C62980000F24EA7 /* Turbolinks.framework */; };
 		22CB5D911C62982800F24EA7 /* Turbolinks.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 22CB5D8D1C62980000F24EA7 /* Turbolinks.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		22CB5D961C6299AB00F24EA7 /* TurbolinksDemo.js in Resources */ = {isa = PBXBuildFile; fileRef = 22CB5D951C6299AB00F24EA7 /* TurbolinksDemo.js */; };
+		92DF45171C81149B0064E606 /* NumbersViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92DF45161C81149B0064E606 /* NumbersViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -32,6 +33,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = 1FC167EE1B55A14900AA6F43;
 			remoteInfo = Turbolinks;
+		};
+		92DF45191C81149C0064E606 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 22CB5D881C62980000F24EA7 /* Turbolinks.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 92DF45071C80F7970064E606;
+			remoteInfo = Tests;
 		};
 /* End PBXContainerItemProxy section */
 
@@ -60,6 +68,7 @@
 		1FC168231B55A16C00AA6F43 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/LaunchScreen.xib; sourceTree = "<group>"; };
 		22CB5D881C62980000F24EA7 /* Turbolinks.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; path = Turbolinks.xcodeproj; sourceTree = "<group>"; };
 		22CB5D951C6299AB00F24EA7 /* TurbolinksDemo.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = TurbolinksDemo.js; sourceTree = "<group>"; };
+		92DF45161C81149B0064E606 /* NumbersViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NumbersViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -102,6 +111,7 @@
 				1F8FC6AA1B55A34500A781C8 /* Main.storyboard */,
 				1FC168221B55A16C00AA6F43 /* LaunchScreen.xib */,
 				1FC168171B55A16C00AA6F43 /* Supporting Files */,
+				92DF45161C81149B0064E606 /* NumbersViewController.swift */,
 			);
 			path = TurbolinksDemo;
 			sourceTree = "<group>";
@@ -118,6 +128,7 @@
 			isa = PBXGroup;
 			children = (
 				22CB5D8D1C62980000F24EA7 /* Turbolinks.framework */,
+				92DF451A1C81149C0064E606 /* Tests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -192,6 +203,13 @@
 			remoteRef = 22CB5D8C1C62980000F24EA7 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
+		92DF451A1C81149C0064E606 /* Tests.xctest */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.cfbundle;
+			path = Tests.xctest;
+			remoteRef = 92DF45191C81149C0064E606 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
 /* End PBXReferenceProxy section */
 
 /* Begin PBXResourcesBuildPhase section */
@@ -213,6 +231,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				1F5A34FA1B67FF900029FDF3 /* AuthenticationController.swift in Sources */,
+				92DF45171C81149B0064E606 /* NumbersViewController.swift in Sources */,
 				1F8FC6A51B55A32000A781C8 /* AppDelegate.swift in Sources */,
 				1F35399F1B6FB21A00AA7462 /* ApplicationController.swift in Sources */,
 				1F8FC6A81B55A33700A781C8 /* WebViewController.swift in Sources */,

--- a/TurbolinksDemo/AppDelegate.swift
+++ b/TurbolinksDemo/AppDelegate.swift
@@ -11,6 +11,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
         NSUserDefaults.standardUserDefaults().registerDefaults(["UserAgent": userAgent])
+        
         return true
     }
 

--- a/TurbolinksDemo/ApplicationController.swift
+++ b/TurbolinksDemo/ApplicationController.swift
@@ -2,16 +2,15 @@ import UIKit
 import WebKit
 import Turbolinks
 
-class ApplicationController: UIViewController, WKNavigationDelegate, SessionDelegate, AuthenticationControllerDelegate {
-    let URL = NSURL(string: "http://localhost:9292")!
-    let webViewProcessPool = WKProcessPool()
-    var mainNavigationController: UINavigationController?
+class ApplicationController: UINavigationController {
+    private let URL = NSURL(string: "http://localhost:9292")!
+    private let webViewProcessPool = WKProcessPool()
 
-    var application: UIApplication {
+    private var application: UIApplication {
         return UIApplication.sharedApplication()
     }
 
-    lazy var webViewConfiguration: WKWebViewConfiguration = {
+    private lazy var webViewConfiguration: WKWebViewConfiguration = {
         let bundle = NSBundle.mainBundle()
         let source = try! String(contentsOfURL: bundle.URLForResource("TurbolinksDemo", withExtension: "js")!, encoding: NSUTF8StringEncoding)
         let userScript = WKUserScript(source: source, injectionTime: .AtDocumentEnd, forMainFrameOnly: true)
@@ -22,7 +21,7 @@ class ApplicationController: UIViewController, WKNavigationDelegate, SessionDele
         return configuration
     }()
 
-    lazy var session: Session = {
+    private lazy var session: Session = {
         let session = Session(webViewConfiguration: self.webViewConfiguration)
         session.delegate = self
         return session
@@ -30,32 +29,21 @@ class ApplicationController: UIViewController, WKNavigationDelegate, SessionDele
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        installMainNavigationController()
         presentVisitableForSession(session, URL: URL)
     }
 
-    func installMainNavigationController() {
-        let mainNavigationController = UINavigationController()
-        self.mainNavigationController = mainNavigationController
-        addChildViewController(mainNavigationController)
-        view.addSubview(mainNavigationController.view)
-        mainNavigationController.didMoveToParentViewController(self)
-    }
-
     private func presentVisitableForSession(session: Session, URL: NSURL, action: Action = .Advance) {
-        if let navigationController = mainNavigationController {
-            let visitable = visitableForSession(session, URL: URL)
-            let viewController = visitable.visitableViewController
-
-            if action == .Advance {
-                navigationController.pushViewController(viewController, animated: true)
-            } else if action == .Replace {
-                navigationController.popViewControllerAnimated(false)
-                navigationController.pushViewController(viewController, animated: false)
-            }
-
-            session.visit(visitable)
+        let visitable = visitableForSession(session, URL: URL)
+        let viewController = visitable.visitableViewController
+        
+        if action == .Advance {
+            pushViewController(viewController, animated: true)
+        } else if action == .Replace {
+            popViewControllerAnimated(false)
+            pushViewController(viewController, animated: false)
         }
+        
+        session.visit(visitable)
     }
 
     private func visitableForSession(session: Session, URL: NSURL) -> Visitable {
@@ -63,8 +51,13 @@ class ApplicationController: UIViewController, WKNavigationDelegate, SessionDele
         visitable.visitableURL = URL
         return visitable
     }
+    
+    private func presentNumbersViewController() {
+        let viewController = NumbersViewController()
+        pushViewController(viewController, animated: true)
+    }
 
-    func presentAuthenticationController() {
+    private func presentAuthenticationController() {
         let authenticationController = AuthenticationController()
         authenticationController.delegate = self
         authenticationController.URL = URL.URLByAppendingPathComponent("sign-in")
@@ -81,57 +74,61 @@ class ApplicationController: UIViewController, WKNavigationDelegate, SessionDele
         alertController.addAction(UIAlertAction(title: "OK", style: .Default, handler: nil))
         presentViewController(alertController, animated: true, completion: nil)
     }
+}
 
-    // MARK: SessionDelegate
-
+extension ApplicationController: SessionDelegate {
     func session(session: Session, didProposeVisitToURL URL: NSURL, withAction action: Action) {
-        presentVisitableForSession(session, URL: URL, action: action)
+        if URL.path == "/numbers" {
+            presentNumbersViewController()
+        } else {
+            presentVisitableForSession(session, URL: URL, action: action)
+        }
     }
-
+    
     func sessionDidStartRequest(session: Session) {
         application.networkActivityIndicatorVisible = true
     }
-
+    
     func session(session: Session, didFailRequestForVisitable visitable: Visitable, withError error: NSError) {
         print("ERROR: \(error)")
         if error.code == ErrorCode.HTTPFailure.rawValue, let statusCode = error.userInfo["statusCode"] as? Int where statusCode == 401 {
-          // Wait for the navigation controller's animation to complete before presenting
-          after(500) {
-            self.presentAuthenticationController()
-          }
+            // Wait for the navigation controller's animation to complete before presenting
+            after(500) {
+                self.presentAuthenticationController()
+            }
         } else {
             session.topmostVisitable?.hideVisitableActivityIndicator()
             presentAlertForError(error)
         }
     }
-
+    
     func sessionDidFinishRequest(session: Session) {
         application.networkActivityIndicatorVisible = false
     }
-
+    
     func sessionDidInitializeWebView(session: Session) {
         session.webView.navigationDelegate = self
     }
+}
 
-    // MARK: AuthenticationControllerDelegate
-
-    func prepareWebViewConfiguration(configuration: WKWebViewConfiguration, forAuthenticationController authenticationController: AuthenticationController) {
-        configuration.processPool = webViewProcessPool
-    }
-
-    func authenticationControllerDidAuthenticate(authenticationController: AuthenticationController) {
-        session.reload()
-        dismissViewControllerAnimated(true, completion: nil)
-    }
-
-    // MARK: WKNavigationDelegate
-
+extension ApplicationController: WKNavigationDelegate {
     func webView(webView: WKWebView, decidePolicyForNavigationAction navigationAction: WKNavigationAction, decisionHandler: (WKNavigationActionPolicy) -> ()) {
         decisionHandler(WKNavigationActionPolicy.Cancel)
-
+        
         if let URL = navigationAction.request.URL {
             UIApplication.sharedApplication().openURL(URL)
         }
+    }
+}
+
+extension ApplicationController: AuthenticationControllerDelegate {
+    func prepareWebViewConfiguration(configuration: WKWebViewConfiguration, forAuthenticationController authenticationController: AuthenticationController) {
+        configuration.processPool = webViewProcessPool
+    }
+    
+    func authenticationControllerDidAuthenticate(authenticationController: AuthenticationController) {
+        session.reload()
+        dismissViewControllerAnimated(true, completion: nil)
     }
 }
 

--- a/TurbolinksDemo/Base.lproj/Main.storyboard
+++ b/TurbolinksDemo/Base.lproj/Main.storyboard
@@ -1,26 +1,21 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9532" systemVersion="15D21" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="tOb-RA-k86">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9532" systemVersion="15D21" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="tbq-el-AUE">
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9530"/>
     </dependencies>
     <scenes>
         <!--Application Controller-->
-        <scene sceneID="GCW-5W-Cmn">
+        <scene sceneID="Z6f-pY-U74">
             <objects>
-                <viewController id="tOb-RA-k86" customClass="ApplicationController" customModule="TurbolinksDemo" customModuleProvider="target" sceneMemberID="viewController">
-                    <layoutGuides>
-                        <viewControllerLayoutGuide type="top" id="8oE-A2-wl5"/>
-                        <viewControllerLayoutGuide type="bottom" id="ESY-ca-B1M"/>
-                    </layoutGuides>
-                    <view key="view" contentMode="scaleToFill" id="9c3-b1-Z9c">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                    </view>
-                </viewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="UbM-jZ-zOb" userLabel="First Responder" sceneMemberID="firstResponder"/>
+                <navigationController id="tbq-el-AUE" customClass="ApplicationController" customModule="TurbolinksDemo" customModuleProvider="target" sceneMemberID="viewController">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="Wy5-gK-0jd">
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="UQ8-Z9-H5O" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="561" y="426"/>
+            <point key="canvasLocation" x="728" y="396"/>
         </scene>
     </scenes>
 </document>

--- a/TurbolinksDemo/NumbersViewController.swift
+++ b/TurbolinksDemo/NumbersViewController.swift
@@ -1,0 +1,28 @@
+import UIKit
+
+private let CellIdentifier = "CellIdentifier"
+
+class NumbersViewController: UITableViewController {
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        title = "Numbers"
+        tableView.registerClass(UITableViewCell.self, forCellReuseIdentifier: CellIdentifier)
+    }
+    
+    override func numberOfSectionsInTableView(tableView: UITableView) -> Int {
+        return 1
+    }
+
+    override func tableView(tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return 100
+    }
+
+    override func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCellWithIdentifier(CellIdentifier, forIndexPath: indexPath)
+
+        let number = indexPath.row + 1
+        cell.textLabel?.text = "Row \(number)"
+
+        return cell
+    }
+}

--- a/TurbolinksDemo/server/lib/turbolinks_demo/views/index.erb
+++ b/TurbolinksDemo/server/lib/turbolinks_demo/views/index.erb
@@ -5,4 +5,5 @@
   <li><a href="/slow">See the loading indicator</a> and test Turbolinks’ preview cache with this slow-loading page.</li>
   <li><a href="/nonexistent">Trigger an HTTP 404</a> to see how Turbolinks handles error responses.</li>
   <li><a href="/protected">Visit a protected area</a> to see how to handle an unauthorized session using a separate web view.</a></li>
+  <li><a href="/numbers">Load a native view controller</a> to see how to intercept the URL and handle it natively.</a></li>
 </ul>


### PR DESCRIPTION
Added a simple example of showing a native view controller in response to a URL click. Also simplified the demo application controller a bit:

![image](https://cloud.githubusercontent.com/assets/21447/13368266/d9b07bd4-dcb6-11e5-9795-7c1b7c787d8d.png)

I just showed a list of numbers since it was easy, but we can change that
![image](https://cloud.githubusercontent.com/assets/21447/13368270/ddb6fc94-dcb6-11e5-97c7-dfc7371d93da.png)
