### PR TITLE
More clear description in demo-server directions

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Then run `pod install`.
 
 ## Running the Demo
 
-Turbolinks for iOS includes a demo application to show off features of the framework.
+This repository includes a demo application to show off features of the framework.
 
 The demo includes a simple HTTP server that serves a Turbolinks 5 web app on `localhost` at port 9292. To start the server, run `TurbolinksDemo/demo-server` from the command line.
 


### PR DESCRIPTION
I looked for the TurboLinksDemo/demo-server command in the xcode project for about 20 minutes ( don't know xcode well at all ). There are probably other people who are as dumb as myself.