### PR TITLE
Open up initial request headers for ColdBootVisit

### DIFF
--- a/Turbolinks/Session.swift
+++ b/Turbolinks/Session.swift
@@ -56,11 +56,11 @@ public class Session: NSObject {
         return topmostVisit?.visitable
     }
 
-    public func visit(visitable: Visitable) {
-        visitVisitable(visitable, action: .Advance)
+    public func visit(visitable: Visitable, initialRequestHeaders: [String: String] = [String: String]()) {
+        visitVisitable(visitable, action: .Advance, initialRequestHeaders: initialRequestHeaders)
     }
     
-    private func visitVisitable(visitable: Visitable, action: Action) {
+    private func visitVisitable(visitable: Visitable, action: Action, initialRequestHeaders: [String: String] = [String: String]()) {
         guard visitable.visitableURL != nil else { return }
 
         visitable.visitableDelegate = self
@@ -71,7 +71,8 @@ public class Session: NSObject {
             visit = JavaScriptVisit(visitable: visitable, action: action, webView: _webView)
             visit.restorationIdentifier = restorationIdentifierForVisitable(visitable)
         } else {
-            visit = ColdBootVisit(visitable: visitable, action: action, webView: _webView)
+            visit = ColdBootVisit(visitable: visitable, action: action, webView: _webView,
+                initialRequestHeaders: initialRequestHeaders)
         }
 
         currentVisit?.cancel()

--- a/Turbolinks/Session.swift
+++ b/Turbolinks/Session.swift
@@ -28,6 +28,7 @@ public extension SessionDelegate {
 
 public class Session: NSObject {
     public weak var delegate: SessionDelegate?
+    public var initialRequestHeaders: [String: String] = [String: String]()
 
     public var webView: WKWebView {
         return _webView
@@ -56,11 +57,11 @@ public class Session: NSObject {
         return topmostVisit?.visitable
     }
 
-    public func visit(visitable: Visitable, initialRequestHeaders: [String: String] = [String: String]()) {
-        visitVisitable(visitable, action: .Advance, initialRequestHeaders: initialRequestHeaders)
+    public func visit(visitable: Visitable) {
+        visitVisitable(visitable, action: .Advance)
     }
     
-    private func visitVisitable(visitable: Visitable, action: Action, initialRequestHeaders: [String: String] = [String: String]()) {
+    private func visitVisitable(visitable: Visitable, action: Action) {
         guard visitable.visitableURL != nil else { return }
 
         visitable.visitableDelegate = self
@@ -82,10 +83,10 @@ public class Session: NSObject {
         visit.start()
     }
 
-    public func reload(requestHeaders: [String: String] = [String: String]()) {
+    public func reload() {
         if let visitable = topmostVisitable {
             initialized = false
-            visit(visitable, initialRequestHeaders: requestHeaders)
+            visit(visitable)
             topmostVisit = currentVisit
         }
     }

--- a/Turbolinks/Session.swift
+++ b/Turbolinks/Session.swift
@@ -82,10 +82,10 @@ public class Session: NSObject {
         visit.start()
     }
 
-    public func reload() {
+    public func reload(requestHeaders: [String: String] = [String: String]()) {
         if let visitable = topmostVisitable {
             initialized = false
-            visit(visitable)
+            visit(visitable, initialRequestHeaders: requestHeaders)
             topmostVisit = currentVisit
         }
     }

--- a/Turbolinks/Visit.swift
+++ b/Turbolinks/Visit.swift
@@ -134,12 +134,21 @@ class Visit: NSObject {
 
 class ColdBootVisit: Visit, WKNavigationDelegate, WebViewPageLoadDelegate {
     private var navigation: WKNavigation?
+    private let initialRequestHeaders: [String: String]
+
+    init(visitable: Visitable, action: Action, webView: WebView, initialRequestHeaders: [String: String]) {
+        self.initialRequestHeaders = initialRequestHeaders
+        super.init(visitable: visitable, action: action, webView: webView)
+    }
 
     override private func startVisit() {
         webView.navigationDelegate = self
         webView.pageLoadDelegate = self
 
-        let request = NSURLRequest(URL: location)
+        let request = NSMutableURLRequest(URL: location)
+        for (field, value) in initialRequestHeaders {
+            request.setValue(value, forHTTPHeaderField: field)
+        }
         navigation = webView.loadRequest(request)
 
         delegate?.visitDidStart(self)


### PR DESCRIPTION
This is a POC proving that #19 can be solved with zero public API changes (thanks to default parameters). I'm assuming that this is out of scope of the framework's goals but I wanted to mention how trivial it is to make the change.