### PR TITLE
Fix css in demo app

### DIFF
--- a/TurbolinksDemo/server/lib/turbolinks_demo/views/layout.erb
+++ b/TurbolinksDemo/server/lib/turbolinks_demo/views/layout.erb
@@ -14,7 +14,7 @@
       });
     </script>
     <style>
-      * { -webkit-user-select: none }
+      *:not(input):not(textarea) { -webkit-user-select: none }
       html { -webkit-text-size-adjust: 100% }
       body { margin: 0; padding: 0 20px }
       body, input { font: -apple-system-body }


### PR DESCRIPTION
I found that when you add some input to any view in demo app server, run the demo in iOS simulator and try to write something to the input, it doesn't work.

![css issue](https://cloud.githubusercontent.com/assets/160575/14178945/560a1382-f75d-11e5-9f9e-eb759708182e.png)

It was little bit confusing for me so I hope that this PR will help.
