### PR TITLE
Support opening email links natively

### DIFF
--- a/Turbolinks.xcodeproj/project.pbxproj
+++ b/Turbolinks.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		1F8FC6B71B55A37400A781C8 /* Session.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F8FC6B01B55A37400A781C8 /* Session.swift */; };
 		1F8FC6B91B55A37400A781C8 /* Visit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F8FC6B11B55A37400A781C8 /* Visit.swift */; };
 		1F8FC6BB1B55A37400A781C8 /* Visitable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F8FC6B21B55A37400A781C8 /* Visitable.swift */; };
+		21B79F431CCEC5E3006DCE4B /* Emailer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21B79F421CCEC5E3006DCE4B /* Emailer.swift */; };
 		224BE7D31B581DE600909D74 /* Turbolinks.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 1FC167EF1B55A14900AA6F43 /* Turbolinks.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		2286D72F1C81FCF500E34B1D /* VisitableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2286D72E1C81FCF500E34B1D /* VisitableView.swift */; };
 		2286D75A1C83F7C600E34B1D /* VisitableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2286D7591C83F7C600E34B1D /* VisitableViewController.swift */; };
@@ -52,6 +53,7 @@
 		1F8FC6B21B55A37400A781C8 /* Visitable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Visitable.swift; sourceTree = "<group>"; };
 		1FC167EF1B55A14900AA6F43 /* Turbolinks.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Turbolinks.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		1FC167F31B55A14900AA6F43 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		21B79F421CCEC5E3006DCE4B /* Emailer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Emailer.swift; sourceTree = "<group>"; };
 		2286D72E1C81FCF500E34B1D /* VisitableView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VisitableView.swift; sourceTree = "<group>"; };
 		2286D7591C83F7C600E34B1D /* VisitableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VisitableViewController.swift; sourceTree = "<group>"; };
 		22960AAA1B9F51E100AA144A /* ScriptMessage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScriptMessage.swift; sourceTree = "<group>"; };
@@ -103,6 +105,7 @@
 		1FC167F11B55A14900AA6F43 /* Turbolinks */ = {
 			isa = PBXGroup;
 			children = (
+				21B79F421CCEC5E3006DCE4B /* Emailer.swift */,
 				22C81A1C1BA72CDA00E47138 /* Action.swift */,
 				22F1C91E1BB1FD6A008FDFFB /* Error.swift */,
 				22960AAA1B9F51E100AA144A /* ScriptMessage.swift */,
@@ -249,6 +252,7 @@
 				2286D72F1C81FCF500E34B1D /* VisitableView.swift in Sources */,
 				22960AAB1B9F51E100AA144A /* ScriptMessage.swift in Sources */,
 				2286D75A1C83F7C600E34B1D /* VisitableViewController.swift in Sources */,
+				21B79F431CCEC5E3006DCE4B /* Emailer.swift in Sources */,
 				1F8FC6B71B55A37400A781C8 /* Session.swift in Sources */,
 				1F8FC6BB1B55A37400A781C8 /* Visitable.swift in Sources */,
 				22C197DE1B59835300749B4E /* WebView.swift in Sources */,

--- a/Turbolinks/Emailer.swift
+++ b/Turbolinks/Emailer.swift
@@ -1,0 +1,120 @@
+import UIKit
+import MessageUI
+
+
+public class Emailer: NSObject, MFMailComposeViewControllerDelegate {
+    
+    var mail: MFMailComposeViewController?
+
+    override init() {
+        self.mail = MFMailComposeViewController()
+    }
+
+    func sendEmail(URL: NSURL) {
+        if MFMailComposeViewController.canSendMail() {
+            mail?.mailComposeDelegate = self
+            setMailAttributesFromUrl(mail!, URL: URL)
+            if let controller = UIApplication.sharedApplication().keyWindow?.visibleViewController() {
+                controller.navigationController?.presentViewController(mail!, animated: true, completion: nil)
+            }
+            
+        } else {
+            // show failure alert
+        }
+    }
+    
+    public func mailComposeController(controller: MFMailComposeViewController, didFinishWithResult result: MFMailComposeResult, error: NSError?) {
+        controller.dismissViewControllerAnimated(true) { () -> Void in
+            self.cycleMailComposer()
+        }
+    }
+    
+    func cycleMailComposer() {
+        mail = nil
+        mail = MFMailComposeViewController()
+    }
+    
+    func setMailAttributesFromUrl(mail: MFMailComposeViewController, URL: NSURL) {
+        var rawURLparts: [AnyObject] = URL.resourceSpecifier.componentsSeparatedByString("?")
+        if rawURLparts.count > 2 {
+            return
+            // invalid URL
+        }
+        
+        var toRecipients: [String] = []
+        let defaultRecipient = rawURLparts[0]
+        if defaultRecipient.length > 0 {
+            toRecipients.append((defaultRecipient as! String).stringByRemovingPercentEncoding!)
+        }
+        
+        if rawURLparts.count == 2 {
+            let queryString = rawURLparts[1]
+            let params = queryString.componentsSeparatedByString("&")
+            for param: String in params {
+                var keyValue = param.componentsSeparatedByString("=")
+                if keyValue.count != 2 {
+                    continue
+                }
+                let key = keyValue[0].lowercaseString
+                var value = keyValue[1]
+                value = value.stringByRemovingPercentEncoding!
+                
+                if (key == "subject") {
+                    mail.setSubject(value)
+                }
+                if (key == "body") {
+                    mail.setMessageBody(value, isHTML: false)
+                }
+                if (key == "to") {
+                    toRecipients.appendContentsOf(value.componentsSeparatedByString(","))
+                }
+                if (key == "cc") {
+                    let recipients: [String] = value.componentsSeparatedByString(",")
+                    mail.setCcRecipients(recipients)
+                }
+                if (key == "bcc") {
+                    let recipients: [String] = value.componentsSeparatedByString(",")
+                    mail.setBccRecipients(recipients)
+                }
+            }
+        }
+        
+        mail.setToRecipients(toRecipients as [String])
+    }
+
+}
+
+extension UIWindow {
+    
+    func visibleViewController() -> UIViewController? {
+        if let rootViewController: UIViewController  = self.rootViewController {
+            return UIWindow.getVisibleViewControllerFrom(rootViewController)
+        }
+        return nil
+    }
+    
+    class func getVisibleViewControllerFrom(vc:UIViewController) -> UIViewController {
+        
+        if vc.isKindOfClass(UINavigationController.self) {
+            
+            let navigationController = vc as! UINavigationController
+            return UIWindow.getVisibleViewControllerFrom( navigationController.visibleViewController!)
+            
+        } else if vc.isKindOfClass(UITabBarController.self) {
+            
+            let tabBarController = vc as! UITabBarController
+            return UIWindow.getVisibleViewControllerFrom(tabBarController.selectedViewController!)
+            
+        } else {
+            
+            if let presentedViewController = vc.presentedViewController {
+                
+                return UIWindow.getVisibleViewControllerFrom(presentedViewController.presentedViewController!)
+                
+            } else {
+                
+                return vc;
+            }
+        }
+    }
+}

--- a/Turbolinks/Session.swift
+++ b/Turbolinks/Session.swift
@@ -34,11 +34,13 @@ public class Session: NSObject {
     }
 
     private var _webView: WebView
+    private var emailer: Emailer
     private var initialized = false
     private var refreshing = false
 
     public init(webViewConfiguration: WKWebViewConfiguration) {
         _webView = WebView(configuration: webViewConfiguration)
+        emailer = Emailer()
         super.init()
         _webView.delegate = self
     }
@@ -275,7 +277,12 @@ extension Session: WKNavigationDelegate {
         decisionHandler(navigationDecision.policy)
 
         if let URL = navigationDecision.externallyOpenableURL {
-            openExternalURL(URL)
+            if URL.scheme == "mailto" {
+                emailer.sendEmail(URL)
+            }
+            else {
+                openExternalURL(URL)
+            }
         } else if navigationDecision.shouldReloadPage {
             reload()
         }


### PR DESCRIPTION
There's really only 1 way to do native email composition in an iOS app and doing so a much nicer experience to do it than to click on a mailto: link and have it switch you to the Mail app. I don't think there'll ever be a case where someone using turbolinks-ios will prefer it to be the other way.

So here's a PR for taking a mailto: link and converting it to a native email popup. I was inspired reading http://stackoverflow.com/questions/25604552/i-have-real-misunderstanding-with-mfmailcomposeviewcontroller-in-swift-ios8-in to see how to parse an email address and strip out the necessary components.

Note that in testing this, it can't be done on a simulator, you have to use a real device to compose emails. Let me know what you think and if there's anything you'd like me to change/add!
 