### PR TITLE
Only remove navigation delegate if set to the current visit

### DIFF
--- a/Turbolinks/Visit.swift
+++ b/Turbolinks/Visit.swift
@@ -147,21 +147,27 @@ class ColdBootVisit: Visit, WKNavigationDelegate, WebViewPageLoadDelegate {
     }
 
     override private func cancelVisit() {
-        webView.navigationDelegate = nil
+        removeNavigationDelegate()
         webView.stopLoading()
         finishRequest()
     }
 
     override private func failVisit() {
-        webView.navigationDelegate = nil
+        removeNavigationDelegate()
         finishRequest()
     }
 
+    private func removeNavigationDelegate() {
+        if webView.navigationDelegate === self {
+            webView.navigationDelegate = nil
+        }
+    }
+    
     // MARK: WKNavigationDelegate
 
     func webView(webView: WKWebView, didFinishNavigation navigation: WKNavigation!) {
         if navigation === self.navigation {
-            webView.navigationDelegate = nil
+            removeNavigationDelegate()
             delegate?.visitDidInitializeWebView(self)
             finishRequest()
         }


### PR DESCRIPTION
This guards against the case where `cancelVisit()` can be called after `sessionDidLoadWebView`, in which case it will nil out the navigationDelegate set by the app and could break application features.