### PR TITLE
Ensure ColdBootVisit has completed successfully before calling visitDidInitializeWebView

### DIFF
--- a/Turbolinks/Session.swift
+++ b/Turbolinks/Session.swift
@@ -152,7 +152,6 @@ extension Session: VisitDelegate {
     func visitDidInitializeWebView(visit: Visit) {
         initialized = true
         delegate?.sessionDidLoadWebView(self)
-        visit.visitable.visitableDidRender()
     }
 
     func visitWillStart(visit: Visit) {

--- a/Turbolinks/Visit.swift
+++ b/Turbolinks/Visit.swift
@@ -67,6 +67,7 @@ class Visit: NSObject {
     private func complete() {
         if state == .Started {
             state = .Completed
+            completeVisit()
             delegate?.visitDidComplete(self)
             delegate?.visitDidFinish(self)
         }
@@ -84,6 +85,7 @@ class Visit: NSObject {
 
     private func startVisit() {}
     private func cancelVisit() {}
+    private func completeVisit() {}
     private func failVisit() {}
 
     // MARK: Navigation
@@ -152,6 +154,11 @@ class ColdBootVisit: Visit, WKNavigationDelegate, WebViewPageLoadDelegate {
         finishRequest()
     }
 
+    override private func completeVisit() {
+        removeNavigationDelegate()
+        delegate?.visitDidInitializeWebView(self)
+    }
+
     override private func failVisit() {
         removeNavigationDelegate()
         finishRequest()
@@ -167,8 +174,6 @@ class ColdBootVisit: Visit, WKNavigationDelegate, WebViewPageLoadDelegate {
 
     func webView(webView: WKWebView, didFinishNavigation navigation: WKNavigation!) {
         if navigation === self.navigation {
-            removeNavigationDelegate()
-            delegate?.visitDidInitializeWebView(self)
             finishRequest()
         }
     }


### PR DESCRIPTION
A `ColdBootVisit` completes successfully when it receives `WebViewPageLoadDelegate`'s `webView(_:didLoadPageWithRestorationIdentifier)` message. This message originates from the web view's Turbolinks adapter, implying that Turbolinks was successfully loaded and can communicate over the JavaScript bridge.

Until we've received this message, we really can't be sure Turbolinks is installed and working, and shouldn't consider the web view initialized.
