### PR TITLE
Convert to Swift 3.0

### DIFF
--- a/Turbolinks.xcodeproj/project.pbxproj
+++ b/Turbolinks.xcodeproj/project.pbxproj
@@ -194,14 +194,16 @@
 			attributes = {
 				LastSwiftMigration = 0700;
 				LastSwiftUpdateCheck = 0720;
-				LastUpgradeCheck = 0700;
+				LastUpgradeCheck = 0800;
 				ORGANIZATIONNAME = Basecamp;
 				TargetAttributes = {
 					1FC167EE1B55A14900AA6F43 = {
 						CreatedOnToolsVersion = 6.3.2;
+						LastSwiftMigration = 0800;
 					};
 					92DF45061C80F7960064E606 = {
 						CreatedOnToolsVersion = 7.2.1;
+						LastSwiftMigration = 0800;
 					};
 				};
 			};
@@ -383,6 +385,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -401,6 +404,8 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.basecamp.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -415,6 +420,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.basecamp.Turbolinks.Tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -427,6 +433,8 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.basecamp.Turbolinks.Tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};

--- a/Turbolinks.xcodeproj/xcshareddata/xcschemes/Turbolinks.xcscheme
+++ b/Turbolinks.xcodeproj/xcshareddata/xcschemes/Turbolinks.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0700"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Turbolinks/Error.swift
+++ b/Turbolinks/Error.swift
@@ -3,8 +3,8 @@ import Foundation
 public let ErrorDomain = "com.basecamp.Turbolinks"
 
 public enum ErrorCode: Int {
-    case HTTPFailure
-    case NetworkFailure
+    case httpFailure
+    case networkFailure
 }
 
 class Error: NSError {

--- a/Turbolinks/ScriptMessage.swift
+++ b/Turbolinks/ScriptMessage.swift
@@ -31,9 +31,9 @@ class ScriptMessage {
         return data["restorationIdentifier"] as? String
     }
    
-    var location: NSURL? {
+    var location: URL? {
         if let locationString = data["location"] as? String {
-            return NSURL(string: locationString)
+            return URL(string: locationString)
         }
         
         return nil
@@ -47,7 +47,7 @@ class ScriptMessage {
         return nil
     }
     
-    static func parse(message: WKScriptMessage) -> ScriptMessage? {
+    static func parse(_ message: WKScriptMessage) -> ScriptMessage? {
         guard let body = message.body as? [String: AnyObject],
             rawName = body["name"] as? String, name = ScriptMessageName(rawValue: rawName),
             data = body["data"] as? [String: AnyObject] else { return nil }

--- a/Turbolinks/Session.swift
+++ b/Turbolinks/Session.swift
@@ -2,27 +2,27 @@ import UIKit
 import WebKit
 
 public protocol SessionDelegate: class {
-    func session(session: Session, didProposeVisitToURL URL: NSURL, withAction action: Action)
-    func session(session: Session, didFailRequestForVisitable visitable: Visitable, withError error: NSError)
-    func session(session: Session, openExternalURL URL: NSURL)
-    func sessionDidLoadWebView(session: Session)
-    func sessionDidStartRequest(session: Session)
-    func sessionDidFinishRequest(session: Session)
+    func session(_ session: Session, didProposeVisitToURL url: URL, withAction action: Action)
+    func session(_ session: Session, didFailRequestForVisitable visitable: Visitable, withError error: NSError)
+    func session(_ session: Session, openExternalURL url: URL)
+    func sessionDidLoadWebView(_ session: Session)
+    func sessionDidStartRequest(_ session: Session)
+    func sessionDidFinishRequest(_ session: Session)
 }
 
 public extension SessionDelegate {
-    func sessionDidLoadWebView(session: Session) {
+    func sessionDidLoadWebView(_ session: Session) {
         session.webView.navigationDelegate = session
     }
 
-    func session(session: Session, openExternalURL URL: NSURL) {
-        UIApplication.sharedApplication().openURL(URL)
+    func session(_ session: Session, openExternalURL url: URL) {
+        UIApplication.shared().openURL(url)
     }
 
-    func sessionDidStartRequest(session: Session) {
+    func sessionDidStartRequest(_ session: Session) {
     }
 
-    func sessionDidFinishRequest(session: Session) {
+    func sessionDidFinishRequest(_ session: Session) {
     }
 }
 
@@ -56,11 +56,11 @@ public class Session: NSObject {
         return topmostVisit?.visitable
     }
 
-    public func visit(visitable: Visitable) {
+    public func visit(_ visitable: Visitable) {
         visitVisitable(visitable, action: .Advance)
     }
     
-    private func visitVisitable(visitable: Visitable, action: Action) {
+    private func visitVisitable(_ visitable: Visitable, action: Action) {
         guard visitable.visitableURL != nil else { return }
 
         visitable.visitableDelegate = self
@@ -93,7 +93,7 @@ public class Session: NSObject {
 
     private var activatedVisitable: Visitable?
 
-    private func activateVisitable(visitable: Visitable) {
+    private func activateVisitable(_ visitable: Visitable) {
         if visitable !== activatedVisitable {
             if let activatedVisitable = self.activatedVisitable {
                 deactivateVisitable(activatedVisitable, showScreenshot: true)
@@ -104,7 +104,7 @@ public class Session: NSObject {
         }
     }
 
-    private func deactivateVisitable(visitable: Visitable, showScreenshot: Bool = false) {
+    private func deactivateVisitable(_ visitable: Visitable, showScreenshot: Bool = false) {
         if visitable === activatedVisitable {
             if showScreenshot {
                 visitable.updateVisitableScreenshot()
@@ -118,14 +118,14 @@ public class Session: NSObject {
 
     // MARK: Visitable restoration identifiers
 
-    private var visitableRestorationIdentifiers = NSMapTable(keyOptions: .WeakMemory, valueOptions: .StrongMemory)
+    private var visitableRestorationIdentifiers: MapTable<UIViewController, NSString> = MapTable(keyOptions: PointerFunctions.Options.weakMemory, valueOptions: PointerFunctions.Options.strongMemory)
 
-    private func restorationIdentifierForVisitable(visitable: Visitable) -> String? {
-        return visitableRestorationIdentifiers.objectForKey(visitable) as? String
+    private func restorationIdentifierForVisitable(_ visitable: Visitable) -> String? {
+        return visitableRestorationIdentifiers.object(forKey: visitable.visitableViewController) as? String
     }
 
-    private func storeRestorationIdentifier(restorationIdentifier: String, forVisitable visitable: Visitable) {
-        visitableRestorationIdentifiers.setObject(restorationIdentifier, forKey: visitable)
+    private func storeRestorationIdentifier(_ restorationIdentifier: String, forVisitable visitable: Visitable) {
+        visitableRestorationIdentifiers.setObject(restorationIdentifier, forKey: visitable.visitableViewController)
     }
 
     private func completeNavigationForCurrentVisit() {
@@ -137,58 +137,58 @@ public class Session: NSObject {
 }
 
 extension Session: VisitDelegate {
-    func visitRequestDidStart(visit: Visit) {
+    func visitRequestDidStart(_ visit: Visit) {
         delegate?.sessionDidStartRequest(self)
     }
 
-    func visitRequestDidFinish(visit: Visit) {
+    func visitRequestDidFinish(_ visit: Visit) {
         delegate?.sessionDidFinishRequest(self)
     }
 
-    func visit(visit: Visit, requestDidFailWithError error: NSError) {
+    func visit(_ visit: Visit, requestDidFailWithError error: NSError) {
         delegate?.session(self, didFailRequestForVisitable: visit.visitable, withError: error)
     }
 
-    func visitDidInitializeWebView(visit: Visit) {
+    func visitDidInitializeWebView(_ visit: Visit) {
         initialized = true
         delegate?.sessionDidLoadWebView(self)
         visit.visitable.visitableDidRender()
     }
 
-    func visitWillStart(visit: Visit) {
+    func visitWillStart(_ visit: Visit) {
         visit.visitable.showVisitableScreenshot()
         activateVisitable(visit.visitable)
     }
 
-    func visitDidStart(visit: Visit) {
+    func visitDidStart(_ visit: Visit) {
         if !visit.hasCachedSnapshot {
             visit.visitable.showVisitableActivityIndicator()
         }
     }
 
-    func visitWillLoadResponse(visit: Visit) {
+    func visitWillLoadResponse(_ visit: Visit) {
         visit.visitable.updateVisitableScreenshot()
         visit.visitable.showVisitableScreenshot()
     }
 
-    func visitDidRender(visit: Visit) {
+    func visitDidRender(_ visit: Visit) {
         visit.visitable.hideVisitableScreenshot()
         visit.visitable.hideVisitableActivityIndicator()
         visit.visitable.visitableDidRender()
     }
 
-    func visitDidComplete(visit: Visit) {
+    func visitDidComplete(_ visit: Visit) {
         if let restorationIdentifier = visit.restorationIdentifier {
             storeRestorationIdentifier(restorationIdentifier, forVisitable: visit.visitable)
         }
     }
 
-    func visitDidFail(visit: Visit) {
+    func visitDidFail(_ visit: Visit) {
         visit.visitable.clearVisitableScreenshot()
         visit.visitable.showVisitableScreenshot()
     }
 
-    func visitDidFinish(visit: Visit) {
+    func visitDidFinish(_ visit: Visit) {
         if refreshing {
             refreshing = false
             visit.visitable.visitableDidRefresh()
@@ -197,17 +197,17 @@ extension Session: VisitDelegate {
 }
 
 extension Session: VisitableDelegate {
-    public func visitableViewWillAppear(visitable: Visitable) {
+    public func visitableViewWillAppear(_ visitable: Visitable) {
         guard let topmostVisit = self.topmostVisit, currentVisit = self.currentVisit else { return }
 
         if visitable === topmostVisit.visitable && visitable.visitableViewController.isMovingToParentViewController() {
             // Back swipe gesture canceled
-            if topmostVisit.state == .Completed {
+            if topmostVisit.state == .completed {
                 currentVisit.cancel()
             } else {
                 visitVisitable(visitable, action: .Advance)
             }
-        } else if visitable === currentVisit.visitable && currentVisit.state == .Started {
+        } else if visitable === currentVisit.visitable && currentVisit.state == .started {
             // Navigating forward - complete navigation early
             completeNavigationForCurrentVisit()
         } else if visitable !== topmostVisit.visitable {
@@ -216,14 +216,14 @@ extension Session: VisitableDelegate {
         }
     }
 
-    public func visitableViewDidAppear(visitable: Visitable) {
+    public func visitableViewDidAppear(_ visitable: Visitable) {
         if let currentVisit = self.currentVisit where visitable === currentVisit.visitable {
             // Appearing after successful navigation
             completeNavigationForCurrentVisit()
-            if currentVisit.state != .Failed {
+            if currentVisit.state != .failed {
                 activateVisitable(visitable)
             }
-        } else if let topmostVisit = self.topmostVisit where visitable === topmostVisit.visitable && topmostVisit.state == .Completed {
+        } else if let topmostVisit = self.topmostVisit where visitable === topmostVisit.visitable && topmostVisit.state == .completed {
             // Reappearing after canceled navigation
             visitable.hideVisitableScreenshot()
             visitable.hideVisitableActivityIndicator()
@@ -231,13 +231,13 @@ extension Session: VisitableDelegate {
         }
     }
 
-    public func visitableDidRequestReload(visitable: Visitable) {
+    public func visitableDidRequestReload(_ visitable: Visitable) {
         if visitable === topmostVisitable {
             reload()
         }
     }
    
-    public func visitableDidRequestRefresh(visitable: Visitable) {
+    public func visitableDidRequestRefresh(_ visitable: Visitable) {
         if visitable === topmostVisitable {
             refreshing = true
             visitable.visitableWillRefresh()
@@ -247,11 +247,11 @@ extension Session: VisitableDelegate {
 }
 
 extension Session: WebViewDelegate {
-    func webView(webView: WebView, didProposeVisitToLocation location: NSURL, withAction action: Action) {
+    func webView(_ webView: WebView, didProposeVisitToLocation location: URL, withAction action: Action) {
         delegate?.session(self, didProposeVisitToURL: location, withAction: action)
     }
     
-    func webViewDidInvalidatePage(webView: WebView) {
+    func webViewDidInvalidatePage(_ webView: WebView) {
         if let visitable = topmostVisitable {
             visitable.updateVisitableScreenshot()
             visitable.showVisitableScreenshot()
@@ -260,7 +260,7 @@ extension Session: WebViewDelegate {
         }
     }
     
-    func webView(webView: WebView, didFailJavaScriptEvaluationWithError error: NSError) {
+    func webView(_ webView: WebView, didFailJavaScriptEvaluationWithError error: NSError) {
         if let currentVisit = self.currentVisit where initialized {
             initialized = false
             currentVisit.cancel()
@@ -270,12 +270,12 @@ extension Session: WebViewDelegate {
 }
 
 extension Session: WKNavigationDelegate {
-    public func webView(webView: WKWebView, decidePolicyForNavigationAction navigationAction: WKNavigationAction, decisionHandler: (WKNavigationActionPolicy) -> ()) {
+    public func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: (WKNavigationActionPolicy) -> ()) {
         let navigationDecision = NavigationDecision(navigationAction: navigationAction)
         decisionHandler(navigationDecision.policy)
 
-        if let URL = navigationDecision.externallyOpenableURL {
-            openExternalURL(URL)
+        if let url = navigationDecision.externallyOpenableURL {
+            openExternalURL(url)
         } else if navigationDecision.shouldReloadPage {
             reload()
         }
@@ -285,12 +285,12 @@ extension Session: WKNavigationDelegate {
         let navigationAction: WKNavigationAction
 
         var policy: WKNavigationActionPolicy {
-            return isMainFrameNavigation ? .Cancel : .Allow
+            return isMainFrameNavigation ? .cancel : .allow
         }
 
-        var externallyOpenableURL: NSURL? {
-            if let URL = navigationAction.request.URL where shouldOpenURLExternally {
-                return URL
+        var externallyOpenableURL: URL? {
+            if let url = navigationAction.request.url where shouldOpenURLExternally {
+                return url
             } else {
                 return nil
             }
@@ -298,20 +298,20 @@ extension Session: WKNavigationDelegate {
 
         var shouldOpenURLExternally: Bool {
             let type = navigationAction.navigationType
-            return isMainFrameNavigation && (type == .LinkActivated || type == .Other)
+            return isMainFrameNavigation && (type == .linkActivated || type == .other)
         }
 
         var shouldReloadPage: Bool {
             let type = navigationAction.navigationType
-            return isMainFrameNavigation && type == .Reload
+            return isMainFrameNavigation && type == .reload
         }
 
         var isMainFrameNavigation: Bool {
-            return navigationAction.targetFrame?.mainFrame ?? false
+            return navigationAction.targetFrame?.isMainFrame ?? false
         }
     }
     
-    private func openExternalURL(URL: NSURL) {
-        delegate?.session(self, openExternalURL: URL)
+    private func openExternalURL(_ url: URL) {
+        delegate?.session(self, openExternalURL: url)
     }
 }

--- a/Turbolinks/Session.swift
+++ b/Turbolinks/Session.swift
@@ -118,7 +118,7 @@ public class Session: NSObject {
 
     // MARK: Visitable restoration identifiers
 
-    private var visitableRestorationIdentifiers: MapTable<UIViewController, NSString> = MapTable(keyOptions: PointerFunctions.Options.weakMemory, valueOptions: PointerFunctions.Options.strongMemory)
+    private var visitableRestorationIdentifiers: MapTable<UIViewController, NSString> = MapTable(keyOptions: PointerFunctions.Options.weakMemory, valueOptions: [])
 
     private func restorationIdentifierForVisitable(_ visitable: Visitable) -> String? {
         return visitableRestorationIdentifiers.object(forKey: visitable.visitableViewController) as? String

--- a/Turbolinks/Tests/ScriptMessageTest.swift
+++ b/Turbolinks/Tests/ScriptMessageTest.swift
@@ -34,7 +34,7 @@ class ScriptMessageTest: XCTestCase {
         XCTAssertEqual(message?.identifier, "123")
         XCTAssertEqual(message?.restorationIdentifier, "abc")
         XCTAssertEqual(message?.action, Action.Advance)
-        XCTAssertEqual(message?.location, NSURL(string: "http://turbolinks.test")!)
+        XCTAssertEqual(message?.location, URL(string: "http://turbolinks.test")!)
     }
 }
 

--- a/Turbolinks/Visitable.swift
+++ b/Turbolinks/Visitable.swift
@@ -2,16 +2,16 @@ import UIKit
 import WebKit
 
 public protocol VisitableDelegate: class {
-    func visitableViewWillAppear(visitable: Visitable)
-    func visitableViewDidAppear(visitable: Visitable)
-    func visitableDidRequestReload(visitable: Visitable)
-    func visitableDidRequestRefresh(visitable: Visitable)
+    func visitableViewWillAppear(_ visitable: Visitable)
+    func visitableViewDidAppear(_ visitable: Visitable)
+    func visitableDidRequestReload(_ visitable: Visitable)
+    func visitableDidRequestRefresh(_ visitable: Visitable)
 }
 
 public protocol Visitable: class {
     weak var visitableDelegate: VisitableDelegate? { get set } 
     var visitableView: VisitableView! { get }
-    var visitableURL: NSURL! { get }
+    var visitableURL: URL! { get }
     func visitableDidRender()
 }
 
@@ -28,7 +28,7 @@ extension Visitable {
         visitableDelegate?.visitableDidRequestReload(self)
     }
 
-    func activateVisitableWebView(webView: WKWebView) {
+    func activateVisitableWebView(_ webView: WKWebView) {
         visitableView.activateWebView(webView, forVisitable: self)
     }
 

--- a/Turbolinks/VisitableView.swift
+++ b/Turbolinks/VisitableView.swift
@@ -22,7 +22,7 @@ public class VisitableView: UIView {
     public var webView: WKWebView?
     private weak var visitable: Visitable?
 
-    public func activateWebView(webView: WKWebView, forVisitable visitable: Visitable) {
+    public func activateWebView(_ webView: WKWebView, forVisitable visitable: Visitable) {
         self.webView = webView
         self.visitable = visitable
         addSubview(webView)
@@ -40,7 +40,7 @@ public class VisitableView: UIView {
     }
 
     private func showOrHideWebView() {
-        webView?.hidden = isShowingScreenshot
+        webView?.isHidden = isShowingScreenshot
     }
 
 
@@ -48,7 +48,7 @@ public class VisitableView: UIView {
 
     public lazy var refreshControl: UIRefreshControl = {
         let refreshControl = UIRefreshControl()
-        refreshControl.addTarget(self, action: #selector(refresh(_:)), forControlEvents: .ValueChanged)
+        refreshControl.addTarget(self, action: #selector(refresh(_:)), for: .valueChanged)
         return refreshControl
     }()
 
@@ -63,7 +63,7 @@ public class VisitableView: UIView {
     }
 
     public var isRefreshing: Bool {
-        return refreshControl.refreshing
+        return refreshControl.isRefreshing
     }
 
     private func installRefreshControl() {
@@ -77,7 +77,7 @@ public class VisitableView: UIView {
         refreshControl.removeFromSuperview()
     }
 
-    func refresh(sender: AnyObject) {
+    func refresh(_ sender: AnyObject) {
         visitable?.visitableViewDidRequestRefresh()
     }
 
@@ -85,9 +85,9 @@ public class VisitableView: UIView {
     // MARK: Activity Indicator
 
     public lazy var activityIndicatorView: UIActivityIndicatorView = {
-        let view = UIActivityIndicatorView(activityIndicatorStyle: .White)
+        let view = UIActivityIndicatorView(activityIndicatorStyle: .white)
         view.translatesAutoresizingMaskIntoConstraints = false
-        view.color = UIColor.grayColor()
+        view.color = UIColor.gray()
         view.hidesWhenStopped = true
         return view
     }()
@@ -100,7 +100,7 @@ public class VisitableView: UIView {
     public func showActivityIndicator() {
         if !isRefreshing {
             activityIndicatorView.startAnimating()
-            bringSubviewToFront(activityIndicatorView)
+            bringSubview(toFront: activityIndicatorView)
         }
     }
 
@@ -112,7 +112,7 @@ public class VisitableView: UIView {
     // MARK: Screenshots
 
     private lazy var screenshotContainerView: UIView = {
-        let view = UIView(frame: CGRectZero)
+        let view = UIView(frame: CGRect.zero)
         view.translatesAutoresizingMaskIntoConstraints = false
         view.backgroundColor = self.backgroundColor
         return view
@@ -128,15 +128,15 @@ public class VisitableView: UIView {
         if let webView = self.webView where !isShowingScreenshot {
             screenshotView?.removeFromSuperview()
             
-            let screenshot = webView.snapshotViewAfterScreenUpdates(false)
+            guard let screenshot = webView.snapshotView(afterScreenUpdates: false) else { return }
             screenshot.translatesAutoresizingMaskIntoConstraints = false
             screenshotContainerView.addSubview(screenshot)
 
             screenshotContainerView.addConstraints([
-                NSLayoutConstraint(item: screenshot, attribute: .CenterX, relatedBy: .Equal, toItem: screenshotContainerView, attribute: .CenterX, multiplier: 1, constant: 0),
-                NSLayoutConstraint(item: screenshot, attribute: .Top, relatedBy: .Equal, toItem: screenshotContainerView, attribute: .Top, multiplier: 1, constant: 0),
-                NSLayoutConstraint(item: screenshot, attribute: .Width, relatedBy: .Equal, toItem: nil, attribute: .NotAnAttribute, multiplier: 1, constant: screenshot.bounds.size.width),
-                NSLayoutConstraint(item: screenshot, attribute: .Height, relatedBy: .Equal, toItem: nil, attribute: .NotAnAttribute, multiplier: 1, constant: screenshot.bounds.size.height)
+                NSLayoutConstraint(item: screenshot, attribute: .centerX, relatedBy: .equal, toItem: screenshotContainerView, attribute: .centerX, multiplier: 1, constant: 0),
+                NSLayoutConstraint(item: screenshot, attribute: .top, relatedBy: .equal, toItem: screenshotContainerView, attribute: .top, multiplier: 1, constant: 0),
+                NSLayoutConstraint(item: screenshot, attribute: .width, relatedBy: .equal, toItem: nil, attribute: .notAnAttribute, multiplier: 1, constant: screenshot.bounds.size.width),
+                NSLayoutConstraint(item: screenshot, attribute: .height, relatedBy: .equal, toItem: nil, attribute: .notAnAttribute, multiplier: 1, constant: screenshot.bounds.size.height)
                 ])
 
             screenshotView = screenshot
@@ -164,14 +164,14 @@ public class VisitableView: UIView {
     // MARK: Hidden Scroll View
 
     private var hiddenScrollView: UIScrollView = {
-        let scrollView = UIScrollView(frame: CGRectZero)
+        let scrollView = UIScrollView(frame: CGRect.zero)
         scrollView.translatesAutoresizingMaskIntoConstraints = false
         scrollView.scrollsToTop = false
         return scrollView
     }()
 
     private func installHiddenScrollView() {
-        insertSubview(hiddenScrollView, atIndex: 0)
+        insertSubview(hiddenScrollView, at: 0)
         addFillConstraintsForSubview(hiddenScrollView)
     }
 
@@ -191,8 +191,8 @@ public class VisitableView: UIView {
         }
     }
 
-    private func addFillConstraintsForSubview(view: UIView) {
-        addConstraints(NSLayoutConstraint.constraintsWithVisualFormat("H:|[view]|", options: [], metrics: nil, views: [ "view": view ]))
-        addConstraints(NSLayoutConstraint.constraintsWithVisualFormat("V:|[view]|", options: [], metrics: nil, views: [ "view": view ]))
+    private func addFillConstraintsForSubview(_ view: UIView) {
+        addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "H:|[view]|", options: [], metrics: nil, views: [ "view": view ]))
+        addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "V:|[view]|", options: [], metrics: nil, views: [ "view": view ]))
     }
 }

--- a/Turbolinks/VisitableViewController.swift
+++ b/Turbolinks/VisitableViewController.swift
@@ -3,25 +3,25 @@ import UIKit
 public class VisitableViewController: UIViewController, Visitable {
     public weak var visitableDelegate: VisitableDelegate?
 
-    public var visitableURL: NSURL!
+    public var visitableURL: URL!
 
-    public convenience init(URL: NSURL) {
+    public convenience init(url: URL) {
         self.init()
-        self.visitableURL = URL
+        self.visitableURL = url
     }
 
     // MARK: Visitable View
 
     public lazy var visitableView: VisitableView! = {
-        let view = VisitableView(frame: CGRectZero)
+        let view = VisitableView(frame: CGRect.zero)
         view.translatesAutoresizingMaskIntoConstraints = false
         return view
     }()
 
     private func installVisitableView() {
         view.addSubview(visitableView)
-        view.addConstraints(NSLayoutConstraint.constraintsWithVisualFormat("H:|[view]|", options: [], metrics: nil, views: [ "view": visitableView ]))
-        view.addConstraints(NSLayoutConstraint.constraintsWithVisualFormat("V:|[view]|", options: [], metrics: nil, views: [ "view": visitableView ]))
+        view.addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "H:|[view]|", options: [], metrics: nil, views: [ "view": visitableView ]))
+        view.addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "V:|[view]|", options: [], metrics: nil, views: [ "view": visitableView ]))
     }
 
     // MARK: Visitable
@@ -34,16 +34,16 @@ public class VisitableViewController: UIViewController, Visitable {
 
     public override func viewDidLoad() {
         super.viewDidLoad()
-        view.backgroundColor = UIColor.whiteColor()
+        view.backgroundColor = UIColor.white()
         installVisitableView()
     }
 
-    public override func viewWillAppear(animated: Bool) {
+    public override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         visitableDelegate?.visitableViewWillAppear(self)
     }
 
-    public override func viewDidAppear(animated: Bool) {
+    public override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         visitableDelegate?.visitableViewDidAppear(self)
     }

--- a/Turbolinks/WebView.swift
+++ b/Turbolinks/WebView.swift
@@ -1,23 +1,23 @@
 import WebKit
 
 protocol WebViewDelegate: class {
-    func webView(webView: WebView, didProposeVisitToLocation location: NSURL, withAction action: Action)
-    func webViewDidInvalidatePage(webView: WebView)
-    func webView(webView: WebView, didFailJavaScriptEvaluationWithError error: NSError)
+    func webView(_ webView: WebView, didProposeVisitToLocation location: URL, withAction action: Action)
+    func webViewDidInvalidatePage(_ webView: WebView)
+    func webView(_ webView: WebView, didFailJavaScriptEvaluationWithError error: NSError)
 }
 
 protocol WebViewPageLoadDelegate: class {
-    func webView(webView: WebView, didLoadPageWithRestorationIdentifier restorationIdentifier: String)
+    func webView(_ webView: WebView, didLoadPageWithRestorationIdentifier restorationIdentifier: String)
 }
 
 protocol WebViewVisitDelegate: class {
-    func webView(webView: WebView, didStartVisitWithIdentifier identifier: String, hasCachedSnapshot: Bool)
-    func webView(webView: WebView, didStartRequestForVisitWithIdentifier identifier: String)
-    func webView(webView: WebView, didCompleteRequestForVisitWithIdentifier identifier: String)
-    func webView(webView: WebView, didFailRequestForVisitWithIdentifier identifier: String, statusCode: Int)
-    func webView(webView: WebView, didFinishRequestForVisitWithIdentifier identifier: String)
-    func webView(webView: WebView, didRenderForVisitWithIdentifier identifier: String)
-    func webView(webView: WebView, didCompleteVisitWithIdentifier identifier: String, restorationIdentifier: String)
+    func webView(_ webView: WebView, didStartVisitWithIdentifier identifier: String, hasCachedSnapshot: Bool)
+    func webView(_ webView: WebView, didStartRequestForVisitWithIdentifier identifier: String)
+    func webView(_ webView: WebView, didCompleteRequestForVisitWithIdentifier identifier: String)
+    func webView(_ webView: WebView, didFailRequestForVisitWithIdentifier identifier: String, statusCode: Int)
+    func webView(_ webView: WebView, didFinishRequestForVisitWithIdentifier identifier: String)
+    func webView(_ webView: WebView, didRenderForVisitWithIdentifier identifier: String)
+    func webView(_ webView: WebView, didCompleteVisitWithIdentifier identifier: String, restorationIdentifier: String)
 }
 
 class WebView: WKWebView {
@@ -26,45 +26,49 @@ class WebView: WKWebView {
     weak var visitDelegate: WebViewVisitDelegate?
 
     init(configuration: WKWebViewConfiguration) {
-        super.init(frame: CGRectZero, configuration: configuration)
+        super.init(frame: CGRect.zero, configuration: configuration)
 
-        let bundle = NSBundle(forClass: self.dynamicType)
-        let source = try! String(contentsOfURL: bundle.URLForResource("WebView", withExtension: "js")!, encoding: NSUTF8StringEncoding)
-        let userScript = WKUserScript(source: source, injectionTime: .AtDocumentEnd, forMainFrameOnly: true)
+        let bundle = Bundle(for: self.dynamicType)
+        let source = try! String(contentsOf: bundle.urlForResource("WebView", withExtension: "js")!, encoding: String.Encoding.utf8)
+        let userScript = WKUserScript(source: source, injectionTime: .atDocumentEnd, forMainFrameOnly: true)
         configuration.userContentController.addUserScript(userScript)
-        configuration.userContentController.addScriptMessageHandler(self, name: "turbolinks")
+        configuration.userContentController.add(self, name: "turbolinks")
 
         translatesAutoresizingMaskIntoConstraints = false
         scrollView.decelerationRate = UIScrollViewDecelerationRateNormal
     }
 
-    func visitLocation(location: NSURL, withAction action: Action, restorationIdentifier: String?) {
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) is not available")
+    }
+
+    func visitLocation(_ location: URL, withAction action: Action, restorationIdentifier: String?) {
         callJavaScriptFunction("webView.visitLocationWithActionAndRestorationIdentifier", withArguments: [location.absoluteString, action.rawValue, restorationIdentifier])
     }
 
-    func issueRequestForVisitWithIdentifier(identifier: String) {
+    func issueRequestForVisitWithIdentifier(_ identifier: String) {
         callJavaScriptFunction("webView.issueRequestForVisitWithIdentifier", withArguments: [identifier])
     }
 
-    func changeHistoryForVisitWithIdentifier(identifier: String) {
+    func changeHistoryForVisitWithIdentifier(_ identifier: String) {
         callJavaScriptFunction("webView.changeHistoryForVisitWithIdentifier", withArguments: [identifier])
     }
 
-    func loadCachedSnapshotForVisitWithIdentifier(identifier: String) {
+    func loadCachedSnapshotForVisitWithIdentifier(_ identifier: String) {
         callJavaScriptFunction("webView.loadCachedSnapshotForVisitWithIdentifier", withArguments: [identifier])
     }
 
-    func loadResponseForVisitWithIdentifier(identifier: String) {
+    func loadResponseForVisitWithIdentifier(_ identifier: String) {
         callJavaScriptFunction("webView.loadResponseForVisitWithIdentifier", withArguments: [identifier])
     }
 
-    func cancelVisitWithIdentifier(identifier: String) {
+    func cancelVisitWithIdentifier(_ identifier: String) {
         callJavaScriptFunction("webView.cancelVisitWithIdentifier", withArguments: [identifier])
     }
 
     // MARK: JavaScript Evaluation
 
-    private func callJavaScriptFunction(functionExpression: String, withArguments arguments: [AnyObject?] = [], completionHandler: ((AnyObject?) -> ())? = nil) {
+    private func callJavaScriptFunction(_ functionExpression: String, withArguments arguments: [AnyObject?] = [], completionHandler: ((AnyObject?) -> ())? = nil) {
         guard let script = scriptForCallingJavaScriptFunction(functionExpression, withArguments: arguments) else {
             NSLog("Error encoding arguments for JavaScript function `%@'", functionExpression)
             return
@@ -83,7 +87,7 @@ class WebView: WKWebView {
         }
     }
 
-    private func scriptForCallingJavaScriptFunction(functionExpression: String, withArguments arguments: [AnyObject?]) -> String? {
+    private func scriptForCallingJavaScriptFunction(_ functionExpression: String, withArguments arguments: [AnyObject?]) -> String? {
         guard let encodedArguments = encodeJavaScriptArguments(arguments) else { return nil }
 
         return
@@ -98,12 +102,12 @@ class WebView: WKWebView {
             "})({})"
     }
 
-    private func encodeJavaScriptArguments(arguments: [AnyObject?]) -> String? {
+    private func encodeJavaScriptArguments(_ arguments: [AnyObject?]) -> String? {
         let arguments = arguments.map { $0 == nil ? NSNull() : $0! }
 
-        if let data = try? NSJSONSerialization.dataWithJSONObject(arguments, options: []),
-            string = NSString(data: data, encoding: NSUTF8StringEncoding) as? String {
-                return string[string.startIndex.successor() ..< string.endIndex.predecessor()]
+        if let data = try? JSONSerialization.data(withJSONObject: arguments, options: []),
+            string = NSString(data: data, encoding: String.Encoding.utf8.rawValue) as? String {
+                return string[string.characters.index(after: string.startIndex) ..< string.characters.index(before: string.endIndex)]
         }
         
         return nil
@@ -111,7 +115,7 @@ class WebView: WKWebView {
 }
 
 extension WebView: WKScriptMessageHandler {
-    func userContentController(userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage) {
+    func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
         guard let message = ScriptMessage.parse(message) else { return }
         
         switch message.name {

--- a/TurbolinksDemo.xcodeproj/project.pbxproj
+++ b/TurbolinksDemo.xcodeproj/project.pbxproj
@@ -217,7 +217,7 @@
 			attributes = {
 				LastSwiftMigration = 0700;
 				LastSwiftUpdateCheck = 0700;
-				LastUpgradeCheck = 0700;
+				LastUpgradeCheck = 0800;
 				ORGANIZATIONNAME = Basecamp;
 				TargetAttributes = {
 					1FC168131B55A16C00AA6F43 = {
@@ -449,6 +449,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.basecamp.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 			};
 			name = Release;
 		};
@@ -474,6 +475,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.basecamp.TurbolinksDemo.UITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				TEST_TARGET_NAME = TurbolinksDemo;
 				USES_XCTRUNNER = YES;
 			};

--- a/TurbolinksDemo/AppDelegate.swift
+++ b/TurbolinksDemo/AppDelegate.swift
@@ -8,29 +8,29 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     // MARK: UIApplicationDelegate
 
-    func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
         return true
     }
 
-    func applicationWillResignActive(application: UIApplication) {
+    func applicationWillResignActive(_ application: UIApplication) {
         // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
         // Use this method to pause ongoing tasks, disable timers, and throttle down OpenGL ES frame rates. Games should use this method to pause the game.
     }
 
-    func applicationDidEnterBackground(application: UIApplication) {
+    func applicationDidEnterBackground(_ application: UIApplication) {
         // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
         // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
     }
 
-    func applicationWillEnterForeground(application: UIApplication) {
+    func applicationWillEnterForeground(_ application: UIApplication) {
         // Called as part of the transition from the background to the inactive state; here you can undo many of the changes made on entering the background.
     }
 
-    func applicationDidBecomeActive(application: UIApplication) {
+    func applicationDidBecomeActive(_ application: UIApplication) {
         // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
     }
 
-    func applicationWillTerminate(application: UIApplication) {
+    func applicationWillTerminate(_ application: UIApplication) {
         // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
     }
 }

--- a/TurbolinksDemo/AuthenticationController.swift
+++ b/TurbolinksDemo/AuthenticationController.swift
@@ -6,13 +6,13 @@ protocol AuthenticationControllerDelegate: class {
 }
 
 class AuthenticationController: UIViewController {
-    var URL: NSURL?
+    var url: URL?
     var webViewConfiguration: WKWebViewConfiguration?
     weak var delegate: AuthenticationControllerDelegate?
 
     lazy var webView: WKWebView = {
         let configuration = self.webViewConfiguration ?? WKWebViewConfiguration()
-        let webView = WKWebView(frame: CGRectZero, configuration: configuration)
+        let webView = WKWebView(frame: CGRect.zero, configuration: configuration)
         webView.translatesAutoresizingMaskIntoConstraints = false
         webView.navigationDelegate = self
         return webView
@@ -22,23 +22,23 @@ class AuthenticationController: UIViewController {
         super.viewDidLoad()
 
         view.addSubview(webView)
-        view.addConstraints(NSLayoutConstraint.constraintsWithVisualFormat("H:|[view]|", options: [], metrics: nil, views: [ "view": webView ]))
-        view.addConstraints(NSLayoutConstraint.constraintsWithVisualFormat("V:|[view]|", options: [], metrics: nil, views: [ "view": webView ]))
+        view.addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "H:|[view]|", options: [], metrics: nil, views: [ "view": webView ]))
+        view.addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "V:|[view]|", options: [], metrics: nil, views: [ "view": webView ]))
 
-        if let URL = self.URL {
-            webView.loadRequest(NSURLRequest(URL: URL))
+        if let url = self.url {
+            webView.load(URLRequest(url: url))
         }
     }
 }
 
 extension AuthenticationController: WKNavigationDelegate {
-    func webView(webView: WKWebView, decidePolicyForNavigationAction navigationAction: WKNavigationAction, decisionHandler: (WKNavigationActionPolicy) -> Void) {
-        if let URL = navigationAction.request.URL where URL != self.URL {
-            decisionHandler(.Cancel)
-            delegate?.authenticationControllerDidAuthenticate(self)
+    func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: (WKNavigationActionPolicy) -> Void) {
+        if let url = navigationAction.request.url where url != self.url {
+            decisionHandler(.cancel)
+            delegate?.authenticationControllerDidAuthenticate(authenticationController: self)
             return
         }
 
-        decisionHandler(.Allow)
+        decisionHandler(.allow)
     }
 }

--- a/TurbolinksDemo/DemoViewController.swift
+++ b/TurbolinksDemo/DemoViewController.swift
@@ -3,9 +3,9 @@ import UIKit
 
 class DemoViewController: Turbolinks.VisitableViewController {
     lazy var errorView: ErrorView = {
-        let view = NSBundle.mainBundle().loadNibNamed("ErrorView", owner: self, options: nil).first as! ErrorView
+        let view = Bundle.main().loadNibNamed("ErrorView", owner: self, options: nil).first as! ErrorView
         view.translatesAutoresizingMaskIntoConstraints = false
-        view.retryButton.addTarget(self, action: #selector(retry(_:)), forControlEvents: .TouchUpInside)
+        view.retryButton.addTarget(self, action: #selector(retry(sender:)), for: .touchUpInside)
         return view
     }()
 
@@ -16,8 +16,8 @@ class DemoViewController: Turbolinks.VisitableViewController {
     }
 
     func installErrorViewConstraints() {
-        view.addConstraints(NSLayoutConstraint.constraintsWithVisualFormat("H:|[view]|", options: [], metrics: nil, views: [ "view": errorView ]))
-        view.addConstraints(NSLayoutConstraint.constraintsWithVisualFormat("V:|[view]|", options: [], metrics: nil, views: [ "view": errorView ]))
+        view.addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "H:|[view]|", options: [], metrics: nil, views: [ "view": errorView ]))
+        view.addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "V:|[view]|", options: [], metrics: nil, views: [ "view": errorView ]))
     }
 
     func retry(sender: AnyObject) {

--- a/TurbolinksDemo/DemoViewController.swift
+++ b/TurbolinksDemo/DemoViewController.swift
@@ -3,7 +3,7 @@ import UIKit
 
 class DemoViewController: Turbolinks.VisitableViewController {
     lazy var errorView: ErrorView = {
-        let view = Bundle.main().loadNibNamed("ErrorView", owner: self, options: nil).first as! ErrorView
+        let view = Bundle.main.loadNibNamed("ErrorView", owner: self, options: nil).first as! ErrorView
         view.translatesAutoresizingMaskIntoConstraints = false
         view.retryButton.addTarget(self, action: #selector(retry(sender:)), for: .touchUpInside)
         return view

--- a/TurbolinksDemo/NumbersViewController.swift
+++ b/TurbolinksDemo/NumbersViewController.swift
@@ -6,19 +6,19 @@ class NumbersViewController: UITableViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         title = "Numbers"
-        tableView.registerClass(UITableViewCell.self, forCellReuseIdentifier: CellIdentifier)
+        tableView.register(UITableViewCell.self, forCellReuseIdentifier: CellIdentifier)
     }
-    
-    override func numberOfSectionsInTableView(tableView: UITableView) -> Int {
+
+    override func numberOfSections(in tableView: UITableView) -> Int {
         return 1
     }
 
-    override func tableView(tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return 100
     }
 
-    override func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCellWithIdentifier(CellIdentifier, forIndexPath: indexPath)
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: CellIdentifier, for: indexPath as IndexPath)
 
         let number = indexPath.row + 1
         cell.textLabel?.text = "Row \(number)"


### PR DESCRIPTION
**This PR converts the framework and demo application to Swift 3.0 syntax.** It was achieved by running the migrator included with Xcode 8 Beta 1 and then fixing any compiler errors. Four design decisions were made as some Framework APIs were changed.

1. All variables and parameters named `URL` were changed to `url` to better align with the Swift 3.0 API design guidelines.
1. `MapTable` requires Objective-C objects as keys and values. To get around this we can store the view controller on `Visitable`, instead of `Visitable` itself as the key. Then use `NSString` over Swift's `String` as the value. The weak to strong reference semantics were unchanged. [Code reference](https://github.com/turbolinks/turbolinks-ios/pull/47/files#diff-3ef8ebdb8ea782b16cf9fde0c47748e2R121).
1. `snapshotView(afterScreenUpdates:)` now returns an optional view so `updateScreenshot()` in `VisitableView` now returns early via `guard`. [Code reference](https://github.com/turbolinks/turbolinks-ios/pull/47/files#diff-422d3a531f723d71b7efc563a7c1515dR131).
1. `init?(coder:)` was added to `WebView` as it is now required. This shouldn't be an issue since `WKWebView` can't be instantiated directly via Storyboards or Xibs anyway. You might want to review the error message, though. [Code reference](https://github.com/turbolinks/turbolinks-ios/pull/47/files#diff-793bba5080e72e6c78d12b0f63c4299aR41).

That said, there are potentially more changes we could make to better align the API with the Swift 3.0 design guidelines. For example, `visitVisitable(_:action:)` could be renamed to `visit(visitable:action:)` and `cancelVisitWithIdentifier(_:)` to `cancelVisit(forIdentifier:)`. Ideally, this PR can start the discussion of how the public API should be changed.

Finally, this will definitely require a version bump as it introduces breaking API changes. According to semantic versioning that would require this to be a 2.0 release, I believe.

Looking forward to discussing these changes!