### PR TITLE
Fix iOS 10 crash with nil snapshot

### DIFF
--- a/Turbolinks/VisitableView.swift
+++ b/Turbolinks/VisitableView.swift
@@ -125,22 +125,20 @@ public class VisitableView: UIView {
     }
 
     public func updateScreenshot() {
-        if let webView = self.webView where !isShowingScreenshot {
-            screenshotView?.removeFromSuperview()
-            
-            let screenshot = webView.snapshotViewAfterScreenUpdates(false)
-            screenshot.translatesAutoresizingMaskIntoConstraints = false
-            screenshotContainerView.addSubview(screenshot)
+        guard let webView = self.webView where !isShowingScreenshot, let screenshot = webView.tl_snapshotView(false) else { return }
+        
+        screenshotView?.removeFromSuperview()
+        screenshot.translatesAutoresizingMaskIntoConstraints = false
+        screenshotContainerView.addSubview(screenshot)
+        
+        screenshotContainerView.addConstraints([
+            NSLayoutConstraint(item: screenshot, attribute: .CenterX, relatedBy: .Equal, toItem: screenshotContainerView, attribute: .CenterX, multiplier: 1, constant: 0),
+            NSLayoutConstraint(item: screenshot, attribute: .Top, relatedBy: .Equal, toItem: screenshotContainerView, attribute: .Top, multiplier: 1, constant: 0),
+            NSLayoutConstraint(item: screenshot, attribute: .Width, relatedBy: .Equal, toItem: nil, attribute: .NotAnAttribute, multiplier: 1, constant: screenshot.bounds.size.width),
+            NSLayoutConstraint(item: screenshot, attribute: .Height, relatedBy: .Equal, toItem: nil, attribute: .NotAnAttribute, multiplier: 1, constant: screenshot.bounds.size.height)
+            ])
 
-            screenshotContainerView.addConstraints([
-                NSLayoutConstraint(item: screenshot, attribute: .CenterX, relatedBy: .Equal, toItem: screenshotContainerView, attribute: .CenterX, multiplier: 1, constant: 0),
-                NSLayoutConstraint(item: screenshot, attribute: .Top, relatedBy: .Equal, toItem: screenshotContainerView, attribute: .Top, multiplier: 1, constant: 0),
-                NSLayoutConstraint(item: screenshot, attribute: .Width, relatedBy: .Equal, toItem: nil, attribute: .NotAnAttribute, multiplier: 1, constant: screenshot.bounds.size.width),
-                NSLayoutConstraint(item: screenshot, attribute: .Height, relatedBy: .Equal, toItem: nil, attribute: .NotAnAttribute, multiplier: 1, constant: screenshot.bounds.size.height)
-                ])
-
-            screenshotView = screenshot
-        }
+        screenshotView = screenshot
     }
     
     public func showScreenshot() {
@@ -194,5 +192,13 @@ public class VisitableView: UIView {
     private func addFillConstraintsForSubview(view: UIView) {
         addConstraints(NSLayoutConstraint.constraintsWithVisualFormat("H:|[view]|", options: [], metrics: nil, views: [ "view": view ]))
         addConstraints(NSLayoutConstraint.constraintsWithVisualFormat("V:|[view]|", options: [], metrics: nil, views: [ "view": view ]))
+    }
+}
+
+extension UIView {
+    // Workaround iOS 10 change where snapshotView returns an optional UIView?, which causes crash on iOS 9
+    // Can remove when we build against the iOS 10 SDK or fixed - rdar://27402891
+    func tl_snapshotView(afterUpdates: Bool) -> UIView? {
+        return snapshotViewAfterScreenUpdates(afterUpdates)
     }
 }


### PR DESCRIPTION
iOS 10 changes snapshotView to return an optional. In some cases, like when the view being snapshotted has been removed from the screen, the snapshot will be nil. Since we expect it to always be non-nil, it will crash on iOS 10 beta, but work fine on iOS 9.

This wraps the snapshot method to return an optional, which we can remove when building against iOS 10 SDK.