### PR TITLE
Update for Xcode 8 and Swift 2.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 ## Requirements
 
-Turbolinks for iOS is compatible with XCode 7/Swift 2.2 and XCode 8/Swift 2.3. It requires iOS 8 or higher. The Swift language requires dependencies to be compiled with the same version as the target that includes them.
+Turbolinks for iOS is compatible with Xcode 8/Swift 2.3. It requires iOS 8 or higher. The Swift language requires dependencies to be compiled with the same version as the target that includes them.
 
 Web views are backed by [WKWebView](https://developer.apple.com/library/ios/documentation/WebKit/Reference/WKWebView_Ref/) for full-speed JavaScript performance.
 
@@ -29,13 +29,7 @@ Add the following to your `Cartfile`:
 github "turbolinks/turbolinks-ios" "master"
 ```
 
-#### XCode 7
-
-Then run `carthage update`.
-
-#### XCode 8 and Swift 2.3
-
-(The XCode 8 command line compiler defaults to Swift 3, so you will need to instruct Carthage to use the Swift 2.3 toolchain.)
+The Xcode 8 command-line compiler defaults to Swift 3, so you will need to instruct Carthage to use the Swift 2.3 toolchain.
 
 Then run `TOOLCHAINS=com.apple.dt.toolchain.Swift_2_3 carthage update`.
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@
 
 ## Requirements
 
-Turbolinks for iOS is written in Swift 2.2 and requires iOS 8 or higher. Web views are backed by [WKWebView](https://developer.apple.com/library/ios/documentation/WebKit/Reference/WKWebView_Ref/) for full-speed JavaScript performance.
+Turbolinks for iOS is compatible with XCode 7/Swift 2.2 and XCode 8/Swift 2.3. It requires iOS 8 or higher. The Swift language requires dependencies to be compiled with the same version as the target that includes them.
+
+Web views are backed by [WKWebView](https://developer.apple.com/library/ios/documentation/WebKit/Reference/WKWebView_Ref/) for full-speed JavaScript performance.
 
 **Note:** You should understand how Turbolinks works with web applications in the browser before attempting to use Turbolinks for iOS. See the [Turbolinks 5 documentation](https://github.com/turbolinks/turbolinks) for details.
 
@@ -27,7 +29,15 @@ Add the following to your `Cartfile`:
 github "turbolinks/turbolinks-ios" "master"
 ```
 
+#### XCode 7
+
 Then run `carthage update`.
+
+#### XCode 8 and Swift 2.3
+
+(The XCode 8 command line compiler defaults to Swift 3, so you will need to instruct Carthage to use the Swift 2.3 toolchain.)
+
+Then run `TOOLCHAINS=com.apple.dt.toolchain.Swift_2_3 carthage update`.
 
 ### Installing with CocoaPods
 

--- a/Turbolinks.xcodeproj/project.pbxproj
+++ b/Turbolinks.xcodeproj/project.pbxproj
@@ -194,14 +194,16 @@
 			attributes = {
 				LastSwiftMigration = 0700;
 				LastSwiftUpdateCheck = 0720;
-				LastUpgradeCheck = 0700;
+				LastUpgradeCheck = 0800;
 				ORGANIZATIONNAME = Basecamp;
 				TargetAttributes = {
 					1FC167EE1B55A14900AA6F43 = {
 						CreatedOnToolsVersion = 6.3.2;
+						LastSwiftMigration = 0800;
 					};
 					92DF45061C80F7960064E606 = {
 						CreatedOnToolsVersion = 7.2.1;
+						LastSwiftMigration = 0800;
 					};
 				};
 			};
@@ -290,8 +292,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -339,8 +343,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -360,6 +366,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -371,6 +378,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -383,6 +391,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 2.3;
 			};
 			name = Debug;
 		};
@@ -390,6 +399,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -401,6 +411,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.basecamp.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 2.3;
 			};
 			name = Release;
 		};
@@ -415,6 +426,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.basecamp.Turbolinks.Tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 2.3;
 			};
 			name = Debug;
 		};
@@ -427,6 +439,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.basecamp.Turbolinks.Tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 2.3;
 			};
 			name = Release;
 		};

--- a/Turbolinks.xcodeproj/project.pbxproj
+++ b/Turbolinks.xcodeproj/project.pbxproj
@@ -378,7 +378,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -399,7 +398,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;

--- a/Turbolinks.xcodeproj/xcshareddata/xcschemes/Turbolinks.xcscheme
+++ b/Turbolinks.xcodeproj/xcshareddata/xcschemes/Turbolinks.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0700"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Turbolinks/VisitableView.swift
+++ b/Turbolinks/VisitableView.swift
@@ -125,7 +125,7 @@ public class VisitableView: UIView {
     }
 
     public func updateScreenshot() {
-        guard let webView = self.webView where !isShowingScreenshot, let screenshot = webView.tl_snapshotView(false) else { return }
+        guard let webView = self.webView where !isShowingScreenshot, let screenshot = webView.snapshotViewAfterScreenUpdates(false) else { return }
         
         screenshotView?.removeFromSuperview()
         screenshot.translatesAutoresizingMaskIntoConstraints = false
@@ -192,13 +192,5 @@ public class VisitableView: UIView {
     private func addFillConstraintsForSubview(view: UIView) {
         addConstraints(NSLayoutConstraint.constraintsWithVisualFormat("H:|[view]|", options: [], metrics: nil, views: [ "view": view ]))
         addConstraints(NSLayoutConstraint.constraintsWithVisualFormat("V:|[view]|", options: [], metrics: nil, views: [ "view": view ]))
-    }
-}
-
-extension UIView {
-    // Workaround iOS 10 change where snapshotView returns an optional UIView?, which causes crash on iOS 9
-    // Can remove when we build against the iOS 10 SDK or fixed - rdar://27402891
-    func tl_snapshotView(afterUpdates: Bool) -> UIView? {
-        return snapshotViewAfterScreenUpdates(afterUpdates)
     }
 }

--- a/Turbolinks/VisitableView.swift
+++ b/Turbolinks/VisitableView.swift
@@ -125,22 +125,20 @@ public class VisitableView: UIView {
     }
 
     public func updateScreenshot() {
-        if let webView = self.webView where !isShowingScreenshot {
-            screenshotView?.removeFromSuperview()
-            
-            let screenshot = webView.snapshotViewAfterScreenUpdates(false)
-            screenshot.translatesAutoresizingMaskIntoConstraints = false
-            screenshotContainerView.addSubview(screenshot)
+        guard let webView = self.webView where !isShowingScreenshot, let screenshot = webView.tl_snapshotView(false) else { return }
+        
+        screenshotView?.removeFromSuperview()
+        screenshot.translatesAutoresizingMaskIntoConstraints = false
+        screenshotContainerView.addSubview(screenshot)
+        
+        screenshotContainerView.addConstraints([
+            NSLayoutConstraint(item: screenshot, attribute: .CenterX, relatedBy: .Equal, toItem: screenshotContainerView, attribute: .CenterX, multiplier: 1, constant: 0),
+            NSLayoutConstraint(item: screenshot, attribute: .Top, relatedBy: .Equal, toItem: screenshotContainerView, attribute: .Top, multiplier: 1, constant: 0),
+            NSLayoutConstraint(item: screenshot, attribute: .Width, relatedBy: .Equal, toItem: nil, attribute: .NotAnAttribute, multiplier: 1, constant: screenshot.bounds.size.width),
+            NSLayoutConstraint(item: screenshot, attribute: .Height, relatedBy: .Equal, toItem: nil, attribute: .NotAnAttribute, multiplier: 1, constant: screenshot.bounds.size.height)
+            ])
 
-            screenshotContainerView.addConstraints([
-                NSLayoutConstraint(item: screenshot, attribute: .CenterX, relatedBy: .Equal, toItem: screenshotContainerView, attribute: .CenterX, multiplier: 1, constant: 0),
-                NSLayoutConstraint(item: screenshot, attribute: .Top, relatedBy: .Equal, toItem: screenshotContainerView, attribute: .Top, multiplier: 1, constant: 0),
-                NSLayoutConstraint(item: screenshot, attribute: .Width, relatedBy: .Equal, toItem: nil, attribute: .NotAnAttribute, multiplier: 1, constant: screenshot.bounds.size.width),
-                NSLayoutConstraint(item: screenshot, attribute: .Height, relatedBy: .Equal, toItem: nil, attribute: .NotAnAttribute, multiplier: 1, constant: screenshot.bounds.size.height)
-                ])
-
-            screenshotView = screenshot
-        }
+        screenshotView = screenshot
     }
     
     public func showScreenshot() {
@@ -194,5 +192,13 @@ public class VisitableView: UIView {
     private func addFillConstraintsForSubview(view: UIView) {
         addConstraints(NSLayoutConstraint.constraintsWithVisualFormat("H:|[view]|", options: [], metrics: nil, views: [ "view": view ]))
         addConstraints(NSLayoutConstraint.constraintsWithVisualFormat("V:|[view]|", options: [], metrics: nil, views: [ "view": view ]))
+    }
+}
+
+extension UIView {
+    // Workaround iOS 10 change where snapshotView returns an optional UIView?, which causes crash on iOS 9
+    // Can remove when we build against the iOS 10 SDK or fixed - rdar://27402891
+    func tl_snapshotView(afterUpdates: Bool) -> UIView? {
+        return snapshotViewAfterScreenUpdates(afterUpdates)
     }
 }

--- a/Turbolinks/WebView.swift
+++ b/Turbolinks/WebView.swift
@@ -37,6 +37,10 @@ class WebView: WKWebView {
         translatesAutoresizingMaskIntoConstraints = false
         scrollView.decelerationRate = UIScrollViewDecelerationRateNormal
     }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
 
     func visitLocation(location: NSURL, withAction action: Action, restorationIdentifier: String?) {
         callJavaScriptFunction("webView.visitLocationWithActionAndRestorationIdentifier", withArguments: [location.absoluteString, action.rawValue, restorationIdentifier])

--- a/Turbolinks/WebView.swift
+++ b/Turbolinks/WebView.swift
@@ -38,9 +38,11 @@ class WebView: WKWebView {
         scrollView.decelerationRate = UIScrollViewDecelerationRateNormal
     }
     
+    #if swift(>=2.3)
     required init?(coder: NSCoder) {
         super.init(coder: coder)
     }
+    #endif
 
     func visitLocation(location: NSURL, withAction action: Action, restorationIdentifier: String?) {
         callJavaScriptFunction("webView.visitLocationWithActionAndRestorationIdentifier", withArguments: [location.absoluteString, action.rawValue, restorationIdentifier])

--- a/TurbolinksDemo.xcodeproj/project.pbxproj
+++ b/TurbolinksDemo.xcodeproj/project.pbxproj
@@ -217,11 +217,15 @@
 			attributes = {
 				LastSwiftMigration = 0700;
 				LastSwiftUpdateCheck = 0700;
-				LastUpgradeCheck = 0700;
+				LastUpgradeCheck = 0800;
 				ORGANIZATIONNAME = Basecamp;
 				TargetAttributes = {
 					1FC168131B55A16C00AA6F43 = {
 						CreatedOnToolsVersion = 6.3.2;
+						LastSwiftMigration = 0800;
+					};
+					8442C5A41C9F83D100FD8CC7 = {
+						LastSwiftMigration = 0800;
 					};
 				};
 			};
@@ -358,8 +362,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -403,8 +409,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -423,6 +431,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;
@@ -437,6 +446,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.basecamp.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 2.3;
 			};
 			name = Debug;
 		};
@@ -449,6 +459,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.basecamp.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 2.3;
 			};
 			name = Release;
 		};
@@ -461,6 +472,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.basecamp.TurbolinksDemo.UITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 2.3;
 				TEST_TARGET_NAME = TurbolinksDemo;
 				USES_XCTRUNNER = YES;
 			};
@@ -474,6 +486,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.basecamp.TurbolinksDemo.UITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 2.3;
 				TEST_TARGET_NAME = TurbolinksDemo;
 				USES_XCTRUNNER = YES;
 			};

--- a/TurbolinksDemo/DemoViewController.swift
+++ b/TurbolinksDemo/DemoViewController.swift
@@ -3,7 +3,7 @@ import UIKit
 
 class DemoViewController: Turbolinks.VisitableViewController {
     lazy var errorView: ErrorView = {
-        let view = NSBundle.mainBundle().loadNibNamed("ErrorView", owner: self, options: nil).first as! ErrorView
+        let view = NSBundle.mainBundle().loadNibNamed("ErrorView", owner: self, options: nil)!.first as! ErrorView
         view.translatesAutoresizingMaskIntoConstraints = false
         view.retryButton.addTarget(self, action: #selector(retry(_:)), forControlEvents: .TouchUpInside)
         return view


### PR DESCRIPTION
The library and demo projects have been updated so they will compile in XCode 7 with Swift 2.2 and XCode 8 with Swift 2.3. The Readme has been updated to reflect this and explain the change needed to build with Carthage when using XCode 8.