### PR TITLE
Use Optional type for screenshot.

### DIFF
--- a/Turbolinks/VisitableView.swift
+++ b/Turbolinks/VisitableView.swift
@@ -125,8 +125,8 @@ public class VisitableView: UIView {
     }
 
     public func updateScreenshot() {
-        guard let webView = self.webView where !isShowingScreenshot, let screenshot = webView.snapshotViewAfterScreenUpdates(false) else { return }
-        
+        guard let webView = self.webView where !isShowingScreenshot, let screenshot: UIView = webView.snapshotViewAfterScreenUpdates(false) else { return }
+
         screenshotView?.removeFromSuperview()
         screenshot.translatesAutoresizingMaskIntoConstraints = false
         screenshotContainerView.addSubview(screenshot)


### PR DESCRIPTION
Fixes #63
The problem is that if the underlying type returned by `webView.snapshotViewAfterScreenUpdates(false)` is something other than a `UIView` it blows up. Using the `as?` operator will safely cast, assigning `nil` if what is returned is not a `UIView`.
