### PR TITLE
Allow override of content inset in VisitableView

### DIFF
--- a/Turbolinks/VisitableView.swift
+++ b/Turbolinks/VisitableView.swift
@@ -20,6 +20,11 @@ public class VisitableView: UIView {
     // MARK: Web View
 
     public var webView: WKWebView?
+    public var contentInset: UIEdgeInsets? {
+        didSet {
+            updateWebViewScrollViewInsets()
+        }
+    }
     private weak var visitable: Visitable?
 
     public func activateWebView(webView: WKWebView, forVisitable visitable: Visitable) {
@@ -180,13 +185,22 @@ public class VisitableView: UIView {
         super.layoutSubviews()
         updateWebViewScrollViewInsets()
     }
-
-    private func updateWebViewScrollViewInsets() {
-        let adjustedInsets = hiddenScrollView.contentInset
-        if let scrollView = webView?.scrollView where scrollView.contentInset.top != adjustedInsets.top && adjustedInsets.top != 0 && !isRefreshing {
+    
+    private func needsUpdateForInsets(adjustedInsets: UIEdgeInsets) -> Bool {
+        guard let scrollView = webView?.scrollView else { return false }
+        return (scrollView.contentInset.top != adjustedInsets.top && adjustedInsets.top != 0) ||
+            (scrollView.contentInset.bottom != adjustedInsets.bottom && adjustedInsets.bottom != 0)
+    }
+    
+    private func updateContentInsets(adjustedInsets: UIEdgeInsets) {
+        if let scrollView = webView?.scrollView where needsUpdateForInsets(adjustedInsets) && !isRefreshing {
             scrollView.scrollIndicatorInsets = adjustedInsets
             scrollView.contentInset = adjustedInsets
         }
+    }
+
+    private func updateWebViewScrollViewInsets() {
+        updateContentInsets(contentInset ?? hiddenScrollView.contentInset)
     }
 
     private func addFillConstraintsForSubview(view: UIView) {

--- a/Turbolinks/VisitableView.swift
+++ b/Turbolinks/VisitableView.swift
@@ -22,7 +22,7 @@ public class VisitableView: UIView {
     public var webView: WKWebView?
     public var contentInset: UIEdgeInsets? {
         didSet {
-            updateWebViewScrollViewInsets()
+            updateContentInsets()
         }
     }
     private weak var visitable: Visitable?
@@ -32,7 +32,7 @@ public class VisitableView: UIView {
         self.visitable = visitable
         addSubview(webView)
         addFillConstraintsForSubview(webView)
-        updateWebViewScrollViewInsets()
+        updateContentInsets()
         installRefreshControl()
         showOrHideWebView()
     }
@@ -183,24 +183,24 @@ public class VisitableView: UIView {
 
     override public func layoutSubviews() {
         super.layoutSubviews()
-        updateWebViewScrollViewInsets()
+        updateContentInsets()
     }
     
-    private func needsUpdateForInsets(adjustedInsets: UIEdgeInsets) -> Bool {
+    private func needsUpdateForContentInsets(adjustedInsets: UIEdgeInsets) -> Bool {
         guard let scrollView = webView?.scrollView else { return false }
         return (scrollView.contentInset.top != adjustedInsets.top && adjustedInsets.top != 0) ||
             (scrollView.contentInset.bottom != adjustedInsets.bottom && adjustedInsets.bottom != 0)
     }
     
-    private func updateContentInsets(adjustedInsets: UIEdgeInsets) {
-        if let scrollView = webView?.scrollView where needsUpdateForInsets(adjustedInsets) && !isRefreshing {
+    private func updateWebViewScrollViewInsets(adjustedInsets: UIEdgeInsets) {
+        if let scrollView = webView?.scrollView where needsUpdateForContentInsets(adjustedInsets) && !isRefreshing {
             scrollView.scrollIndicatorInsets = adjustedInsets
             scrollView.contentInset = adjustedInsets
         }
     }
 
-    private func updateWebViewScrollViewInsets() {
-        updateContentInsets(contentInset ?? hiddenScrollView.contentInset)
+    private func updateContentInsets() {
+        updateWebViewScrollViewInsets(contentInset ?? hiddenScrollView.contentInset)
     }
 
     private func addFillConstraintsForSubview(view: UIView) {

--- a/Turbolinks/VisitableViewController.swift
+++ b/Turbolinks/VisitableViewController.swift
@@ -47,4 +47,16 @@ public class VisitableViewController: UIViewController, Visitable {
         super.viewDidAppear(animated)
         visitableDelegate?.visitableViewDidAppear(self)
     }
+
+    /*
+     If the visitableView is a child of the main view, and anchored to its top and bottom, then it's
+     unlikely you will need to customize the layout. But more complicated view hierarchies and layout 
+     may require explicit control over the contentInset. Below is an example of setting the contentInset 
+     to the layout guides.
+     
+    public override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        visitableView.contentInset = UIEdgeInsets(top: topLayoutGuide.length, left: 0, bottom: bottomLayoutGuide.length, right: 0)
+    }
+    */
 }


### PR DESCRIPTION
I ran into a situation where iOS's management of the content inset wasn't giving the right behavior when VisitableView was part of a child view controller that could be swapped in and out.

This change preserves the existing behavior while allowing the content inset to be overridden.

I also changed it to consider the bottom inset, as well, when determining if the insets have changed.