### PR TITLE
Resolve Callback Race in ColdBootVisit

### DIFF
--- a/Turbolinks/Visit.swift
+++ b/Turbolinks/Visit.swift
@@ -155,7 +155,6 @@ class ColdBootVisit: Visit, WKNavigationDelegate, WebViewPageLoadDelegate {
     }
 
     override fileprivate func completeVisit() {
-        removeNavigationDelegate()
         delegate?.visitDidInitializeWebView(self)
     }
 
@@ -174,6 +173,7 @@ class ColdBootVisit: Visit, WKNavigationDelegate, WebViewPageLoadDelegate {
 
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
         if navigation === self.navigation {
+            removeNavigationDelegate()
             finishRequest()
         }
     }


### PR DESCRIPTION
With the change implemented in #45, the WKNavigationDelegate on
ColdBootVisit is removed when the WebViewPageLoadDelegate method
webView:didLoadPageWithRestorationIdentifier: is called. This
callback originates from the WKScriptMessageHandler inside
Turbolinks.WebView.

In production, I'm seeing cases where this
method can be called *before* the webView:didFinish: callback
of WKNavigationDelegate. As a result, the SessionDelegate
sessionDidFinishRequest: method is never called. The behavior
is indeterminate. It appears to be a race condition with no
guarantee of which will execute first.

Ensuring the delegate is not removed until after the webview finishes
loading prevents this callback from getting dropped.