### PR TITLE
Fix webkit user script messages not being called when web view is hidden

### DIFF
--- a/Turbolinks/WebView.js
+++ b/Turbolinks/WebView.js
@@ -97,7 +97,8 @@
         },
 
         postMessageAfterNextRepaint: function(name, data) {
-            if (document.visibilityState == "hidden") {
+            // Post immediately if document is hidden or message may be queued by call to rAF
+            if (document.hidden) {
                 this.postMessage(name, data);
             } else {
                 var postMessage = this.postMessage.bind(this, name, data)

--- a/Turbolinks/WebView.js
+++ b/Turbolinks/WebView.js
@@ -97,10 +97,14 @@
         },
 
         postMessageAfterNextRepaint: function(name, data) {
-            var postMessage = this.postMessage.bind(this, name, data)
-            requestAnimationFrame(function() {
-                requestAnimationFrame(postMessage)
-            })
+            if (document.visibilityState == "hidden") {
+                this.postMessage(name, data);
+            } else {
+                var postMessage = this.postMessage.bind(this, name, data)
+                requestAnimationFrame(function() {
+                    requestAnimationFrame(postMessage)
+                })
+            }
         }
     }
 


### PR DESCRIPTION
In a few places, we call `postMessageAfterNextRepaint` which will delay the message until after a repaint. The problem is if the web view isn't visible at the time of that call, it will be queued until it becomes visible again. This can cause a few subtle and unexpected timing problems.

This checks the visibility state and posts the message immediately when hidden.