### PR TITLE
Fix scroll position being incorrect

### DIFF
--- a/Turbolinks/VisitableView.swift
+++ b/Turbolinks/VisitableView.swift
@@ -32,7 +32,6 @@ open class VisitableView: UIView {
         self.visitable = visitable
         addSubview(webView)
         addFillConstraints(forView: webView)
-        updateContentInsets()
         installRefreshControl()
         showOrHideWebView()
     }
@@ -199,7 +198,11 @@ open class VisitableView: UIView {
     }
 
     private func updateContentInsets() {
-        updateWebViewScrollViewInsets(contentInset ?? hiddenScrollView.contentInset)
+        if #available(iOS 11, *) {
+            updateWebViewScrollViewInsets(contentInset ?? hiddenScrollView.adjustedContentInset)
+        } else {
+            updateWebViewScrollViewInsets(contentInset ?? hiddenScrollView.contentInset)
+        }
     }
 
     private func addFillConstraints(forView view: UIView) {

--- a/Turbolinks/WebView.swift
+++ b/Turbolinks/WebView.swift
@@ -36,6 +36,10 @@ class WebView: WKWebView {
 
         translatesAutoresizingMaskIntoConstraints = false
         scrollView.decelerationRate = UIScrollViewDecelerationRateNormal
+        
+        if #available(iOS 11, *) {
+            scrollView.contentInsetAdjustmentBehavior = .never
+        }
     }
     
     required init?(coder: NSCoder) {

--- a/TurbolinksDemo/ApplicationController.swift
+++ b/TurbolinksDemo/ApplicationController.swift
@@ -26,6 +26,10 @@ class ApplicationController: UINavigationController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        
+        // Switching this to false will prevent content from sitting beneath scrollbar
+        navigationBar.isTranslucent = true
+        
         presentVisitableForSession(session, url: url)
     }
 


### PR DESCRIPTION
Fixes issues mentioned in https://github.com/turbolinks/turbolinks-ios/issues/94.

There are a few related issues here.

1. We'd call `updateContentInsets` in the `VisitableView` when adding the web view, but before we had accurate insets, so they would be 0. Simultaneously, Turbolinks would scroll the web view as part of standard loading/restoring process, and then the content inset would later get correctly set, and the position would be off
2. On iOS 11, there are new behaviors for `UIScrollView` with regards to adjusting the content inset automatically. For now, we disable that behavior on the webView's scrollView and continue to do our own adjustment.
3. In both iOS 10 and iOS 11 with the current code (before this PR), the content inset is always correct, it's just that the scroll position gets applied incorrectly.

This is a band-aid, but ultimately I think we need to refactor how scrolling is managed in Turbolinks. As of iOS 11, we should be able to do away with all the hacks and just let iOS adjust the content inset automatically. In order to do that, we may need to add the scroll management to the native portion of the framework so we have more control over when that gets applied.