### PR TITLE
Update the visitable titles example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,11 +178,15 @@ By default, Turbolinks for iOS sets your Visitable view controller’s `title` p
 If you want to customize the title or pull it from another element on the page, you can implement the `visitableDidRender` method on your Visitable:
 
 ```swift
-func visitableDidRender() {
+override func visitableDidRender() {
     title = formatTitle(visitableView.webView?.title)
 }
 
-func formatTitle(title: String) -> String {
+func formatTitle(title: String?) -> String {
+    guard let title = title else {
+        return "Default Title"
+    }
+    
     // ...
 }
 ```


### PR DESCRIPTION
When implementing this code in Xcode I had to mark `visitableDidRender` as an override so figured that belonged in the example code too. Also as `webView` is optional it means `formatTitle` needs to handle that case, so I've added a guard clause example.