### PR TITLE
Fix behavior when tapping on a same-page anchor link

### DIFF
--- a/Turbolinks/WebView.js
+++ b/Turbolinks/WebView.js
@@ -51,10 +51,18 @@
             }
         },
 
+        locationIsSamePageAnchor: function (location) {
+            return location.anchor && location.requestURL == this.currentVisit.location.requestURL
+        },
+
         // Adapter interface
 
         visitProposedToLocationWithAction: function(location, action) {
-            this.postMessage("visitProposed", { location: location.absoluteURL, action: action })
+            if (this.locationIsSamePageAnchor(location)) {
+                this.controller.scrollToAnchor(location.anchor)
+            } else {
+                this.postMessage("visitProposed", { location: location.absoluteURL, action: action })
+            }
         },
 
         visitStarted: function(visit) {


### PR DESCRIPTION
This is an attempt to address the issue with tapping on same-page anchor links as noted by @javan here: https://github.com/turbolinks/turbolinks/pull/285#issuecomment-356318342.

## The Problem

When tapping on a link to a same-page anchor, it is expected that the page should scroll to the anchor. In the browser, the hash location and scroll position is added to the history so the that visitor can jump back to where they came from. This behaviour is implemented in https://github.com/turbolinks/turbolinks/pull/285 but is still broken on turbolinks-ios/android.

In native Turbolinks apps, new visits are typically pushed onto a navigation stack. However in the case of same-page anchors, this doesn’t really make sense. Also, the concept of jumping back to a previous scroll position does not make sense, because “Back” usually pops the entire screen from the stack.

## The Solution

This PR detects whether the proposed visit is to an anchor on the same page, and rather than start a new visit, it just scrolls to the anchor.

## Notes on the implementation

This approach should be relatively easy to port to the turbolinks-android bridge, but there are a few things which could be improved, and I thought I’d get some feedback before proceeding.

### Reducing repetition of `locationIsSamePageAnchor`

The `locationIsSamePageAnchor ` function could probably be moved to `Turbolinks.Controller` since it also has access to the `currentVisit`. This could then be used in turbolinks, turbolinks-ios, and turbolinks-android.

### `visit.location` goes out of sync

Bypassing the visit for same-page anchors means that the current visit’s `location` is not accurate. The actual location string will be something like `http://example.com#anchor`, whereas the visit’s location string will still be `http://example.com`. This could be fixed by adding a setter method to the visit e.g.

```coffeescript
class Turbolinks.Visit
  constructor: (@controller, location, @action) ->
    …
    @setLocation(location)
    …
  
  setLocation: (location) ->
    @location = Turbolinks.Location.wrap(location)
```

and then be called from `visitProposedToLocationWithAction`:

```js
visitProposedToLocationWithAction: function(location, action) {
    if (this.locationIsSamePageAnchor(location)) {
        this.controller.scrollToAnchor(location.anchor)
        this.currentVisit.setLocation(location)
    } else {
        this.postMessage("visitProposed", { location: location.absoluteURL, action: action })
    }
}
```

Bypassing the visit process also means that in-flight visits won’t be cancelled. I’m not sure if this is a big deal, or if there might be a way round it.

___

Also, thanks to @samoli for helping on this!