### PR TITLE
Fix Swift compiler warning

### DIFF
--- a/Turbolinks/Visitable.swift
+++ b/Turbolinks/Visitable.swift
@@ -9,7 +9,7 @@ public protocol VisitableDelegate: class {
 }
 
 public protocol Visitable: class {
-    weak var visitableDelegate: VisitableDelegate? { get set } 
+    var visitableDelegate: VisitableDelegate? { get set } 
     var visitableView: VisitableView! { get }
     var visitableURL: URL! { get }
     func visitableDidRender()


### PR DESCRIPTION
> `weak` should not be applied to a property declaration in a protocol and will be disallowed in future versions