### PR TITLE
Changing enums to camel case

### DIFF
--- a/Turbolinks/Action.swift
+++ b/Turbolinks/Action.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 public enum Action: String {
-    case Advance = "advance"
-    case Replace = "replace"
-    case Restore = "restore"
+    case advance = "advance"
+    case replace = "replace"
+    case restore = "restore"
 }

--- a/Turbolinks/ScriptMessage.swift
+++ b/Turbolinks/ScriptMessage.swift
@@ -1,17 +1,17 @@
 import WebKit
 
 enum ScriptMessageName: String {
-    case PageLoaded = "pageLoaded"
-    case ErrorRaised = "errorRaised"
-    case VisitProposed = "visitProposed"
-    case VisitStarted = "visitStarted"
-    case VisitRequestStarted = "visitRequestStarted"
-    case VisitRequestCompleted = "visitRequestCompleted"
-    case VisitRequestFailed = "visitRequestFailed"
-    case VisitRequestFinished = "visitRequestFinished"
-    case VisitRendered = "visitRendered"
-    case VisitCompleted = "visitCompleted"
-    case PageInvalidated = "pageInvalidated"
+    case pageLoaded = "pageLoaded"
+    case errorRaised = "errorRaised"
+    case visitProposed = "visitProposed"
+    case visitStarted = "visitStarted"
+    case visitRequestStarted = "visitRequestStarted"
+    case visitRequestCompleted = "visitRequestCompleted"
+    case visitRequestFailed = "visitRequestFailed"
+    case visitRequestFinished = "visitRequestFinished"
+    case visitRendered = "visitRendered"
+    case visitCompleted = "visitCompleted"
+    case pageInvalidated = "pageInvalidated"
 }
 
 class ScriptMessage {

--- a/Turbolinks/Session.swift
+++ b/Turbolinks/Session.swift
@@ -57,7 +57,7 @@ open class Session: NSObject {
     }
 
     open func visit(_ visitable: Visitable) {
-        visitVisitable(visitable, action: .Advance)
+        visitVisitable(visitable, action: .advance)
     }
 
     fileprivate func visitVisitable(_ visitable: Visitable, action: Action) {
@@ -204,14 +204,14 @@ extension Session: VisitableDelegate {
             if topmostVisit.state == .completed {
                 currentVisit.cancel()
             } else {
-                visitVisitable(visitable, action: .Advance)
+                visitVisitable(visitable, action: .advance)
             }
         } else if visitable === currentVisit.visitable && currentVisit.state == .started {
             // Navigating forward - complete navigation early
             completeNavigationForCurrentVisit()
         } else if visitable !== topmostVisit.visitable {
             // Navigating backward
-            visitVisitable(visitable, action: .Restore)
+            visitVisitable(visitable, action: .restore)
         }
     }
 

--- a/Turbolinks/WebView.swift
+++ b/Turbolinks/WebView.swift
@@ -125,27 +125,27 @@ extension WebView: WKScriptMessageHandler {
         guard let message = ScriptMessage.parse(message) else { return }
         
         switch message.name {
-        case .PageLoaded:
+        case .pageLoaded:
             pageLoadDelegate?.webView(self, didLoadPageWithRestorationIdentifier: message.restorationIdentifier!)
-        case .PageInvalidated:
+        case .pageInvalidated:
             delegate?.webViewDidInvalidatePage(self)
-        case .VisitProposed:
+        case .visitProposed:
             delegate?.webView(self, didProposeVisitToLocation: message.location!, withAction: message.action!)
-        case .VisitStarted:
+        case .visitStarted:
             visitDelegate?.webView(self, didStartVisitWithIdentifier: message.identifier!, hasCachedSnapshot: message.data["hasCachedSnapshot"] as! Bool)
-        case .VisitRequestStarted:
+        case .visitRequestStarted:
             visitDelegate?.webView(self, didStartRequestForVisitWithIdentifier: message.identifier!)
-        case .VisitRequestCompleted:
+        case .visitRequestCompleted:
             visitDelegate?.webView(self, didCompleteRequestForVisitWithIdentifier: message.identifier!)
-        case .VisitRequestFailed:
+        case .visitRequestFailed:
             visitDelegate?.webView(self, didFailRequestForVisitWithIdentifier: message.identifier!, statusCode: message.data["statusCode"] as! Int)
-        case .VisitRequestFinished:
+        case .visitRequestFinished:
             visitDelegate?.webView(self, didFinishRequestForVisitWithIdentifier: message.identifier!)
-        case .VisitRendered:
+        case .visitRendered:
             visitDelegate?.webView(self, didRenderForVisitWithIdentifier: message.identifier!)
-        case .VisitCompleted:
+        case .visitCompleted:
             visitDelegate?.webView(self, didCompleteVisitWithIdentifier: message.identifier!, restorationIdentifier: message.restorationIdentifier!)
-        case .ErrorRaised:
+        case .errorRaised:
             let error = message.data["error"] as? String
             NSLog("JavaScript error: %@", error ?? "<unknown error>")
         }


### PR DESCRIPTION
This PR changes enums `Action` and `ScriptMessageName` to be camel case which is in line with the other enums in this framework as well as the Swift standard.