### PR TITLE
added additional headers feature

### DIFF
--- a/Turbolinks/Session.swift
+++ b/Turbolinks/Session.swift
@@ -10,6 +10,10 @@ public protocol SessionDelegate: class {
     func sessionDidFinishRequest(_ session: Session)
 }
 
+public protocol SessionDataSource: class {
+    func session(_ session: Session, additionalHeadersForRequestWithURL url: URL) -> [String: String]?
+}
+
 public extension SessionDelegate {
     func sessionDidLoadWebView(_ session: Session) {
         session.webView.navigationDelegate = session
@@ -26,8 +30,15 @@ public extension SessionDelegate {
     }
 }
 
+public extension SessionDataSource {
+    func session(_ session: Session, additionalHeadersForRequestWithURL url: URL) -> [String: String]? {
+        return nil
+    }
+}
+
 open class Session: NSObject {
     open weak var delegate: SessionDelegate?
+    open weak var dataSource: SessionDataSource?
 
     open var webView: WKWebView {
         return _webView
@@ -78,6 +89,7 @@ open class Session: NSObject {
         currentVisit = visit
 
         visit.delegate = self
+        visit.dataSource = self
         visit.start()
     }
 
@@ -192,6 +204,12 @@ extension Session: VisitDelegate {
             refreshing = false
             visit.visitable.visitableDidRefresh()
         }
+    }
+}
+
+extension Session: VisitDataSource {
+    func visit(_ visit: Visit, additionalHeadersForRequestWithURL url: URL) -> [String : String]? {
+        return dataSource?.session(self, additionalHeadersForRequestWithURL: url)
     }
 }
 


### PR DESCRIPTION
It's very useful in case we have authenticated via API and want to go into web version using turbolinks without signing in every time app is opened (for example). Of course we can use OTAC (server will check it and redirect to page returning cookies) or something else, but it's a bit complicated for beginners. So we can give developer an opportunity to add additional headers to requests/