### PR TITLE
Make sure finishRequest() is always called for cold boot visits

### DIFF
--- a/Turbolinks/Visit.swift
+++ b/Turbolinks/Visit.swift
@@ -173,6 +173,7 @@ class ColdBootVisit: Visit, WKNavigationDelegate, WebViewPageLoadDelegate {
     // MARK: WKNavigationDelegate
 
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        print("ColdBootVisit \(#function)")
         if navigation === self.navigation {
             finishRequest()
         }

--- a/Turbolinks/Visit.swift
+++ b/Turbolinks/Visit.swift
@@ -157,6 +157,7 @@ class ColdBootVisit: Visit, WKNavigationDelegate, WebViewPageLoadDelegate {
     override fileprivate func completeVisit() {
         removeNavigationDelegate()
         delegate?.visitDidInitializeWebView(self)
+        finishRequest()
     }
 
     override fileprivate func failVisit() {

--- a/TurbolinksDemo/ApplicationController.swift
+++ b/TurbolinksDemo/ApplicationController.swift
@@ -3,7 +3,7 @@ import WebKit
 import Turbolinks
 
 class ApplicationController: UINavigationController {
-    fileprivate let url = URL(string: "http://localhost:9292")!
+    fileprivate let url = URL(string: "http://localhost:9292/slow")!
     fileprivate let webViewProcessPool = WKProcessPool()
 
     fileprivate var application: UIApplication {
@@ -94,10 +94,12 @@ extension ApplicationController: SessionDelegate {
     
     func sessionDidStartRequest(_ session: Session) {
         application.isNetworkActivityIndicatorVisible = true
+        print("\(ObjectIdentifier(self)) \(#function)")
     }
 
     func sessionDidFinishRequest(_ session: Session) {
         application.isNetworkActivityIndicatorVisible = false
+        print("\(ObjectIdentifier(self)) \(#function)")
     }
 }
 

--- a/TurbolinksDemo/Base.lproj/Main.storyboard
+++ b/TurbolinksDemo/Base.lproj/Main.storyboard
@@ -1,18 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="tbq-el-AUE">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="eaa-mb-s0X">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13527"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
-        <!--Application Controller-->
+        <!--Item-->
         <scene sceneID="Z6f-pY-U74">
             <objects>
                 <navigationController id="tbq-el-AUE" customClass="ApplicationController" customModule="TurbolinksDemo" customModuleProvider="target" sceneMemberID="viewController">
+                    <tabBarItem key="tabBarItem" title="Item" id="LxP-Sz-mgD"/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="Wy5-gK-0jd">
                         <rect key="frame" x="0.0" y="20" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
@@ -20,7 +21,39 @@
                 </navigationController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="UQ8-Z9-H5O" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="728" y="396"/>
+            <point key="canvasLocation" x="1750" y="-19"/>
+        </scene>
+        <!--Tab Bar Controller-->
+        <scene sceneID="Y0t-Dx-7qH">
+            <objects>
+                <tabBarController automaticallyAdjustsScrollViewInsets="NO" id="eaa-mb-s0X" sceneMemberID="viewController">
+                    <toolbarItems/>
+                    <tabBar key="tabBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="BHz-O6-87e">
+                        <autoresizingMask key="autoresizingMask"/>
+                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                    </tabBar>
+                    <connections>
+                        <segue destination="tbq-el-AUE" kind="relationship" relationship="viewControllers" id="pH8-S8-ocZ"/>
+                        <segue destination="tpO-JS-r9F" kind="relationship" relationship="viewControllers" id="eH9-CE-I7e"/>
+                    </connections>
+                </tabBarController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="R76-u9-Qvc" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="727.20000000000005" y="395.35232383808096"/>
+        </scene>
+        <!--Item-->
+        <scene sceneID="uJX-Wo-IJP">
+            <objects>
+                <navigationController id="tpO-JS-r9F" customClass="ApplicationController" customModule="TurbolinksDemo" customModuleProvider="target" sceneMemberID="viewController">
+                    <tabBarItem key="tabBarItem" title="Item" id="NVo-Gq-WPZ"/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="Dzd-n0-ywL">
+                        <rect key="frame" x="0.0" y="20" width="375" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="aLs-7Y-Wob" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1750" y="758"/>
         </scene>
     </scenes>
 </document>

--- a/TurbolinksDemo/server/lib/turbolinks_demo/app.rb
+++ b/TurbolinksDemo/server/lib/turbolinks_demo/app.rb
@@ -23,7 +23,7 @@ module TurbolinksDemo
     end
 
     get '/slow' do
-      sleep 2
+      sleep 5
       @title = 'Slow Page'
       erb :slow, layout: :layout
     end


### PR DESCRIPTION
Hello and thanks for a great framework!

In a Turbolinks app I'm currently working on, we display multiple navigation controllers in a tab bar controller. Each navigation controller has their own `Session` but share the same `WKProcessPool`.

When showing and hiding the network activity indicator in response to receiving `sessionDidStartRequest(_:)` and `sessionDidEndRequest(_:)` messages, I found that `sessionDidEndRequest(_:)` wasn't called if I switched to a different tab before the request hda finished. Since we're using reference counting to show and hide the indicator, this caused the indicator to never be hidden.

In 11d71c3, I have made some changes that make this easier to reproduce: just start the demo app, switch to the second tab, and watch the printed messages in the Xcode debugger output pane.

We should make sure to remove this commit before merging if you decide doing so makes sense.

The reason `sessionDidEndRequest(_:)` isn't called is the the `WKWebView` won't send the `webView(_:didFinish:)` message to its `navigationDelegate` (i.e. the `ColdBootVisit`) after switching to a different tab. I don't know why it doesn't do so and can't find any documentation describing this behavior.

In 4515ceb, I add a call to `finishRequest()` in `ColdBootVisit.completeVisit()` to fix this problem. Since `finishRequest()` only calls `sessionDidEndRequest(_:)` once and we know that the request must have finished at this point I think this should be safe.

Let me know what you think!