### PR TITLE
Fix executable bundle path

### DIFF
--- a/TurbolinksDemo/demo-server
+++ b/TurbolinksDemo/demo-server
@@ -16,7 +16,7 @@ find-writable-gem-home() {
 }
 
 find-bundle-executable() {
-  gem contents bundler | grep "/exe/bundle$" | head -n 1
+  gem contents bundler | grep "/bin/bundle$" | head -n 1
 }
 
 warn() {


### PR DESCRIPTION
Bundle executables on ruby 2.6 is located on /bin path instead /exe path