### PR TITLE
Update Visitable.visitableURL after following a redirect

### DIFF
--- a/Turbolinks/Visit.swift
+++ b/Turbolinks/Visit.swift
@@ -230,8 +230,10 @@ class ColdBootVisit: Visit, WKNavigationDelegate, WebViewPageLoadDelegate {
 
     // MARK: WebViewPageLoadDelegate
 
-    func webView(_ webView: WebView, didLoadPageWithRestorationIdentifier restorationIdentifier: String) {
+    func webView(_ webView: WebView, didLoadPageWithRestorationIdentifier restorationIdentifier: String, location: URL) {
         self.restorationIdentifier = restorationIdentifier
+        self.location = location
+        visitable.visitableURL = location
         delegate?.visitDidRender(self)
         complete()
     }
@@ -314,9 +316,11 @@ class JavaScriptVisit: Visit, WebViewVisitDelegate {
         }
     }
 
-    func webView(_ webView: WebView, didCompleteVisitWithIdentifier identifier: String, restorationIdentifier: String) {
+    func webView(_ webView: WebView, didCompleteVisitWithIdentifier identifier: String, restorationIdentifier: String, location: URL) {
         if identifier == self.identifier {
             self.restorationIdentifier = restorationIdentifier
+            self.location = location
+            visitable.visitableURL = location
             complete()
         }
     }

--- a/Turbolinks/Visitable.swift
+++ b/Turbolinks/Visitable.swift
@@ -11,7 +11,7 @@ public protocol VisitableDelegate: class {
 public protocol Visitable: class {
     var visitableDelegate: VisitableDelegate? { get set } 
     var visitableView: VisitableView! { get }
-    var visitableURL: URL! { get }
+    var visitableURL: URL! { get set }
     func visitableDidRender()
 }
 

--- a/Turbolinks/WebView.js
+++ b/Turbolinks/WebView.js
@@ -8,7 +8,8 @@
     WebView.prototype = {
         pageLoaded: function() {
             var restorationIdentifier = this.controller.restorationIdentifier
-            this.postMessageAfterNextRepaint("pageLoaded", { restorationIdentifier: restorationIdentifier })
+            var location = this.controller.location
+            this.postMessageAfterNextRepaint("pageLoaded", { restorationIdentifier: restorationIdentifier, location: location.absoluteURL })
         },
 
         errorRaised: function(error) {
@@ -83,7 +84,8 @@
         },
 
         visitCompleted: function(visit) {
-            this.postMessageAfterNextRepaint("visitCompleted", { identifier: visit.identifier, restorationIdentifier: visit.restorationIdentifier })
+            visit.followRedirect()
+            this.postMessageAfterNextRepaint("visitCompleted", { identifier: visit.identifier, restorationIdentifier: visit.restorationIdentifier, location: visit.location.absoluteURL })
         },
 
         pageInvalidated: function() {

--- a/Turbolinks/WebView.swift
+++ b/Turbolinks/WebView.swift
@@ -7,7 +7,7 @@ protocol WebViewDelegate: class {
 }
 
 protocol WebViewPageLoadDelegate: class {
-    func webView(_ webView: WebView, didLoadPageWithRestorationIdentifier restorationIdentifier: String)
+    func webView(_ webView: WebView, didLoadPageWithRestorationIdentifier restorationIdentifier: String, location: URL)
 }
 
 protocol WebViewVisitDelegate: class {
@@ -17,7 +17,7 @@ protocol WebViewVisitDelegate: class {
     func webView(_ webView: WebView, didFailRequestForVisitWithIdentifier identifier: String, statusCode: Int)
     func webView(_ webView: WebView, didFinishRequestForVisitWithIdentifier identifier: String)
     func webView(_ webView: WebView, didRenderForVisitWithIdentifier identifier: String)
-    func webView(_ webView: WebView, didCompleteVisitWithIdentifier identifier: String, restorationIdentifier: String)
+    func webView(_ webView: WebView, didCompleteVisitWithIdentifier identifier: String, restorationIdentifier: String, location: URL)
 }
 
 class WebView: WKWebView {
@@ -126,7 +126,7 @@ extension WebView: WKScriptMessageHandler {
         
         switch message.name {
         case .PageLoaded:
-            pageLoadDelegate?.webView(self, didLoadPageWithRestorationIdentifier: message.restorationIdentifier!)
+            pageLoadDelegate?.webView(self, didLoadPageWithRestorationIdentifier: message.restorationIdentifier!, location: message.location!)
         case .PageInvalidated:
             delegate?.webViewDidInvalidatePage(self)
         case .VisitProposed:
@@ -144,7 +144,7 @@ extension WebView: WKScriptMessageHandler {
         case .VisitRendered:
             visitDelegate?.webView(self, didRenderForVisitWithIdentifier: message.identifier!)
         case .VisitCompleted:
-            visitDelegate?.webView(self, didCompleteVisitWithIdentifier: message.identifier!, restorationIdentifier: message.restorationIdentifier!)
+            visitDelegate?.webView(self, didCompleteVisitWithIdentifier: message.identifier!, restorationIdentifier: message.restorationIdentifier!, location: message.location!)
         case .ErrorRaised:
             let error = message.data["error"] as? String
             NSLog("JavaScript error: %@", error ?? "<unknown error>")


### PR DESCRIPTION
Hi!

When reloading a page using pull-to-refresh after visiting a URL that redirects somewhere else, the **original** URL is reloaded instead of the URL that was redirected to.

This is inconsistent with how Turbolinks works in a browser where the address bar is updated using the History API causing reloading the page to reload the URL that was redirected to.

This happens both for cold boot visits and JavaScript visits.

This PR is an attempt to solve this problem by having the Turbolinks WebView adapter report back the final location after loading a page (for cold boot visits) or completing a visit (for JavaScript visits).

This might be a terrible solution but maybe it can help illustrate the problem?

I've also created [a minimal Rails app](https://github.com/calleerlandsson/test-turbolinks-redirection) that can be used to test this by changing `ApplicationController.url` to point to port 3000 in the demo app: 

```diff
 import Turbolinks
 
 class ApplicationController: UINavigationController {
-    fileprivate let url = URL(string: "http://localhost:9292")!
+    fileprivate let url = URL(string: "http://localhost:3000")!
     fileprivate let webViewProcessPool = WKProcessPool()
 
     fileprivate var application: UIApplication {
```

When the demo app starts it will first `GET /` that will redirect to `/redirect_target` causing another `GET` for this path.

Before this PR, reloading the page using pull-to-refresh, would cause the same series of requests: `GET /` then `GET /redirect_target`.

After this PR, it only causes a `GET /redirect_target`.

The exact same behavior can be observed when clicking the "Go to /" link causing a JavaScript visit instead of a cold boot visit.