### PR TITLE
Turbo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Turbolinks for iOS
 
+⚠️ Note: this repo is no longer being maintained. We recommend migrating to [Turbo iOS](https://github.com/hotwired/turbo-ios) which supports both Turbo 7 and Turbolinks 5 apps. Follow the [migration guide](https://github.com/hotwired/turbo-ios/blob/main/Docs/Migration.md) to update from this framework to Turbo. ⚠️
+
+---
+
 **Build high-fidelity hybrid apps with native navigation and a single shared web view.** Turbolinks for iOS provides the tooling to wrap your [Turbolinks 5](https://github.com/turbolinks/turbolinks)-enabled web app in a native iOS shell. It manages a single WKWebView instance across multiple view controllers, giving you native navigation UI with all the client-side performance benefits of Turbolinks.
 
 ## Features


### PR DESCRIPTION
We've just released a new version of the Turbolinks framework, which is now called [Turbo](https://turbo.hotwire.dev). As we built HEY over the last two years, we've been working on also updating Turbolinks in tandem to enable us to improve the way we make our apps. That ended up being different enough to warrant a new name. The new iOS framework is [Turbo iOS](https://github.com/hotwired/turbo-ios).

Most of the big changes are on the JavaScript side, and the iOS framework is mostly the same with improvements and some refactoring. The new Turbo framework does support both Turbo and Turbolinks 5, so you can update your native apps to the new framework independently of your web apps. There's a [migration guide](https://github.com/hotwired/turbo-ios/blob/main/Docs/Migration.md) here, and I recommend anyone using this framework migrates to Turbo as that's where future work will occur. Please test your apps against the beta release of Turbo and open an issue on that repo if you have any trouble migrating.